### PR TITLE
Throw away supervisord logs to support unpriv containers

### DIFF
--- a/10-htcondor.conf
+++ b/10-htcondor.conf
@@ -2,6 +2,6 @@
 command=/usr/sbin/condor_master -f
 autorestart=true
 startsecs=20
-stdout_logfile=/dev/fd/1
+stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 redirect_stderr=true

--- a/10-htcondor.conf
+++ b/10-htcondor.conf
@@ -1,4 +1,4 @@
-[condor_master]
+[program:condor_master]
 command=/usr/sbin/condor_master -f
 autorestart=true
 startsecs=20

--- a/10-htcondor.conf
+++ b/10-htcondor.conf
@@ -2,3 +2,6 @@
 command=/usr/sbin/condor_master -f
 autorestart=true
 startsecs=20
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true

--- a/10-htcondor.conf
+++ b/10-htcondor.conf
@@ -2,6 +2,5 @@
 command=/usr/sbin/condor_master -f
 autorestart=true
 startsecs=20
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
+stdout_logfile=/dev/null
 redirect_stderr=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ RUN useradd osg \
  && curl -s -o /usr/sbin/osgvo-node-advertise https://raw.githubusercontent.com/opensciencegrid/osg-flock/master/node-check/osgvo-node-advertise \
  && chmod 755 /usr/sbin/osgvo-user-job-wrapper /usr/sbin/osgvo-node-advertise
 
+# Override the software-base supervisord.conf to throw away supervisord logs
+COPY supervisord.conf /etc/supervisord.conf
 COPY 10-setup-htcondor.sh /etc/osg/image-init.d/
 COPY 10-cleanup-htcondor.sh /etc/osg/image-cleanup.d/
 COPY 10-htcondor.conf /etc/supervisord.d/

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,3 +30,5 @@ COPY 10-htcondor.conf /etc/supervisord.d/
 COPY 50-main.config /etc/condor/config.d/
  
 RUN chown -R osg: ~osg 
+
+WORKDIR /tmp

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,4 +1,4 @@
 [supervisord]
 nodaemon=true
 logfile=/dev/null
-logfile_maxybtes=0
+logfile_maxbytes=0

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,4 @@
+[supervisord]
+nodaemon=true
+logfile=/dev/null
+logfile_maxybtes=0

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,3 +2,20 @@
 nodaemon=true
 logfile=/dev/null
 logfile_maxbytes=0
+
+[unix_http_server]
+file=/tmp/supervisor.sock   ; (the path to the socket file)
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock         ; use a unix:// URL  for a unix socket
+loglevel=debug
+
+[include]
+files=/etc/supervisord.d/*.conf
+
+[program:crond]
+command=/usr/sbin/crond -n
+autorestart=true


### PR DESCRIPTION
Purdue is seeing issues where the container can't write to `/var/log`. I'm asking them to test these changes