### PR TITLE
Add cvmfsexec (SOFTWARE-4549)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,9 +46,10 @@ RUN yum -y install git \
  # Again, needs to be 1777 so the unpriv user can extract into it. \
  && chmod 1777 /cvmfsexec
 
+# Set this to turn off cvmfsexec
+ENV NO_CVMFSEXEC=
 # Space separated list of repos to mount at startup (if using cvmfsexec)
 ENV CVMFSEXEC_REPOS=oasis.opensciencegrid.org
-
 # The proxy to use for CVMFS; leave this blank to use the default
 ENV CVMFS_HTTP_PROXY=
 # The quota limit in MB for CVMFS; leave this blank to use the default

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,13 @@ COPY supervisord.conf /etc/supervisord.conf
 
 RUN yum -y install git \
  && yum clean all \
- && git clone https://github.com/cvmfs/cvmfsexec /cvmfsexec-template
+ && git clone https://github.com/cvmfs/cvmfsexec /cvmfsexec
 
 # Space separated list of repos to mount at startup (if using cvmfsexec)
 ENV CVMFSEXEC_REPOS=oasis.opensciencegrid.org
+
+# The distribution to download cvmfsexec data from
+ENV CVMFSEXEC_DIST=osg
 
 COPY entrypoint.sh /bin/entrypoint.sh
 COPY 10-setup-htcondor.sh /etc/osg/image-init.d/

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,11 @@ RUN yum -y install git \
 # Space separated list of repos to mount at startup (if using cvmfsexec)
 ENV CVMFSEXEC_REPOS=oasis.opensciencegrid.org
 
+# The proxy to use for CVMFS; leave this blank to use the default
+ENV CVMFS_HTTP_PROXY=
+# The quota limit in MB for CVMFS; leave this blank to use the default
+ENV CVMFS_QUOTA_LIMIT=
+
 COPY entrypoint.sh /bin/entrypoint.sh
 COPY 10-setup-htcondor.sh /etc/osg/image-init.d/
 COPY 10-cleanup-htcondor.sh /etc/osg/image-cleanup.d/

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,12 +30,10 @@ COPY supervisord.conf /etc/supervisord.conf
 
 RUN yum -y install git \
  && yum clean all \
- && git clone https://github.com/cvmfs/cvmfsexec ~osg/cvmfsexec \
- && cd ~osg/cvmfsexec \
- && ./makedist osg
+ && git clone https://github.com/cvmfs/cvmfsexec /cvmfsexec-template
 
 # Space separated list of repos to mount at startup (if using cvmfsexec)
-ENV CVMFS_REPOS=oasis.opensciencegrid.org
+ENV CVMFSEXEC_REPOS=oasis.opensciencegrid.org
 
 COPY entrypoint.sh /bin/entrypoint.sh
 COPY 10-setup-htcondor.sh /etc/osg/image-init.d/

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,10 +46,9 @@ RUN yum -y install git \
  # Again, needs to be 1777 so the unpriv user can extract into it. \
  && chmod 1777 /cvmfsexec
 
-# Set this to turn off cvmfsexec
-ENV NO_CVMFSEXEC=
-# Space separated list of repos to mount at startup (if using cvmfsexec)
-ENV CVMFSEXEC_REPOS=oasis.opensciencegrid.org
+# Space separated list of repos to mount at startup (if using cvmfsexec);
+# leave this blank to disable cvmfsexec
+ENV CVMFSEXEC_REPOS=
 # The proxy to use for CVMFS; leave this blank to use the default
 ENV CVMFS_HTTP_PROXY=
 # The quota limit in MB for CVMFS; leave this blank to use the default

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,7 @@ RUN chown -R osg: ~osg
 RUN mkdir -p /pilot && chmod 1777 /pilot
 
 WORKDIR /pilot
+# We need an ENTRYPOINT so we can use cvmfsexec with any command (such as bash for debugging purposes)
 ENTRYPOINT ["/bin/entrypoint.sh"]
 # Adding ENTRYPOINT clears CMD
 CMD ["/usr/local/sbin/supervisord_startup.sh"]

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ You can store the logs outside of the container by bind-mounting a directory to
 
 cvmfsexec requires the additional options `--device=/dev/fuse` and
 `--security-opt=seccomp=unconfined`.  Supporting Singularity jobs when using
-cvmfsexec requires privileged containers (`--privileged`).
+cvmfsexec requires privileged containers (`--privileged`).  Using privileged containers avoids the need for those two additional options and all the `--cap-add` options without adding much risk so it is recommended.
 
 The following example invocation will:
 -   Use a token for authentication

--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ to `/cvmfs-cache`.
 You can store the logs outside of the container by bind-mounting a directory to
 `/cvmfs-logs`.
 
-cvmfsexec requires the additional option `--device=/dev/fuse`.
+cvmfsexec requires the additional options `--device=/dev/fuse` and
+(for Docker) `--security-opt=seccomp=unconfined`.
 
 Here is an example invocation using a token for authentication, using cvmfsexec
 to mount the OASIS and singularity repos instead of bind-mounting `/cvmfs`,
@@ -143,6 +144,7 @@ docker run -it --rm --user osg \
        --cap-add=DAC_READ_SEARCH \
        --cap-add=SYS_ADMIN --cap-add=SYS_CHROOT --cap-add=SYS_PTRACE \
        --device=/dev/fuse \
+       --security-opt=seccomp=unconfined \
        -v /var/cache/cvmfsexec:/cvmfsexec-cache \
        -v /var/log/cvmfsexec:/cvmfsexec-logs \
        -v /path/to/token:/etc/condor/tokens-orig.d/flock.opensciencegrid.org

--- a/README.md
+++ b/README.md
@@ -135,13 +135,15 @@ You can store the logs outside of the container by bind-mounting a directory to
 `/cvmfs-logs`.
 
 cvmfsexec requires the additional options `--device=/dev/fuse` and
-(for Docker) `--security-opt=seccomp=unconfined`.  Supporting Singularity
-jobs when using cvmfsexec requires privileged containers (`--privileged`).
+`--security-opt=seccomp=unconfined`.  Supporting Singularity jobs when using
+cvmfsexec requires privileged containers (`--privileged`).
 
-Here is an example invocation using a token for authentication, using cvmfsexec
-to mount the OASIS and singularity repos instead of bind-mounting `/cvmfs`,
-sending the cache to `/var/cache/cvmfsexec` and the logs to
-`/var/log/cvmfsexec`, and adding support for Singularity jobs:
+The following example invocation will:
+-   Use a token for authentication
+-   Use cvmfsexec to mount the OASIS and Singularity CVMFS repos
+-   Use `/var/cache/cvmfsexec` on the host for the CVMFS cache
+-   Use `/var/log/cvmfsexec` on the host for the CVMFS logs
+-   Support Singularity jobs
 
 ```
 docker run -it --rm --user osg \

--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ You can store the logs outside of the container by bind-mounting a directory to
 `/cvmfs-logs`.
 
 cvmfsexec requires the additional options `--device=/dev/fuse` and
-(for Docker) `--security-opt=seccomp=unconfined`.
+(for Docker) `--security-opt=seccomp=unconfined`.  Supporting Singularity
+jobs when using cvmfsexec requires privileged containers (`--privileged`).
 
 Here is an example invocation using a token for authentication, using cvmfsexec
 to mount the OASIS and singularity repos instead of bind-mounting `/cvmfs`,
@@ -140,11 +141,7 @@ sending the cache to `/var/cache/cvmfsexec` and the logs to
 
 ```
 docker run -it --rm --user osg \
-       --cap-add=DAC_OVERRIDE --cap-add=SETUID --cap-add=SETGID \
-       --cap-add=DAC_READ_SEARCH \
-       --cap-add=SYS_ADMIN --cap-add=SYS_CHROOT --cap-add=SYS_PTRACE \
-       --device=/dev/fuse \
-       --security-opt=seccomp=unconfined \
+       --privileged
        -v /var/cache/cvmfsexec:/cvmfsexec-cache \
        -v /var/log/cvmfsexec:/cvmfsexec-logs \
        -v /path/to/token:/etc/condor/tokens-orig.d/flock.opensciencegrid.org \

--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ There are several environment variables you can set for cvmfsexec:
 
 -   `CVMFSEXEC_REPOS` - this is a comma-separated list of CVMFS repos to mount,
     if using cvmfsexec; leave this blank to disable cvmfsexec.
-    OSG jobs frequently use the OASIS repo (`oasis.opensciencegrid.org`).
+    OSG jobs frequently use the OASIS repo (`oasis.opensciencegrid.org`) and
+    the singularity repo (`singularity.opensciencegrid.org`).
 
 -   `CVMFS_HTTP_PROXY` - this sets the proxy to use for CVMFS; if left blank
     it will find the best one via WLCG Web Proxy Auto Discovery.
@@ -132,9 +133,9 @@ You can store the logs outside of the container by bind-mounting a directory to
 cvmfsexec requires the additional option `--device=/dev/fuse`.
 
 Here is an example invocation using a token for authentication, using cvmfsexec
-to mount the OASIS repos instead of bind-mounting `/cvmfs`, sending the cache
-to `/var/cache/cvmfsexec` and the logs to `/var/log/cvmfsexec`,
-and adding support for Singularity jobs:
+to mount the OASIS and singularity repos instead of bind-mounting `/cvmfs`,
+sending the cache to `/var/cache/cvmfsexec` and the logs to
+`/var/log/cvmfsexec`, and adding support for Singularity jobs:
 
 ```
 docker run -it --rm --user osg \
@@ -149,7 +150,7 @@ docker run -it --rm --user osg \
        -e GLIDEIN_ResourceName="..." \
        -e GLIDEIN_Start_Extra="True" \
        -e OSG_SQUID_LOCATION="..." \
-       -e CVMFSEXEC_REPOS=oasis.opensciencegrid.org \
+       -e CVMFSEXEC_REPOS="oasis.opensciencegrid.org singularity.opensciencegrid.org" \
        opensciencegrid/osgvo-docker-pilot:latest
 ```
 

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ $ singularity build osgvo-pilot.sif docker://opensciencegrid/osgvo-docker-pilot
 If you don't have CVMFS available on the host, the container can still make
 CVMFS available by using [cvmfsexec](https://github.com/cvmfs/cvmfsexec#readme).
 
-This will require a kernel version >= 3.10.0-1127 on an EL7-compatible host
-or >= 4.18 on an EL8-compatible host, or user namespaces enabled by hand --
+This will require a kernel version >= 3.10.0-1127 on an EL7-compatible host with user namespaces enabled
+or >= 4.18 on an EL8-compatible host --
 see the cvmfsexec README linked above for details.
 
 This will also require granting the container some additional privileges, which
@@ -95,7 +95,7 @@ you can do in one of two ways:
     `--security-opt seccomp=unconfined --security-opt systempaths=unconfined --device=/dev/fuse`
     to the `docker run` invocation.
 
-The second option will add only the minimum necessary privileges for cvmfsexec.
+The second option will add only the minimum necessary privileges for cvmfsexec.  You can add additional security to that option by also adding `--security-opt no-new-privileges`.
 
 Using cvmfsexec takes place in the entrypoint, which means it will still happen
 even if you specify a different command to run, such as `bash`.  You can bypass
@@ -105,15 +105,15 @@ clears the command.
 
 There are several environment variables you can set for cvmfsexec:
 
--   `NO_CVMFSEXEC` - set this to disable cvmfsexec.
+-   `NO_CVMFSEXEC` - set this to any non-empty value to disable cvmfsexec.
 
 -   `CVMFSEXEC_REPOS` - this is a comma-separated list of CVMFS repos to mount, if using cvmfsexec.
     Set this to blank to avoid using cvmfsexec, in which case you won't need to
     add the above permissions to your container.  The default is to mount the
     OASIS repo (oasis.opensciencegrid.org).
 
--   `CVMFS_HTTP_PROXY` - this sets the proxy to use for CVMFS; leave this blank
-    to find the best one via wlcg-lpad.
+-   `CVMFS_HTTP_PROXY` - this sets the proxy to use for CVMFS; if left blank
+    it will find the best one via WLCG Web Proxy Auto Discovery.
 
 -   `CVMFS_QUOTA_LIMIT` - the quota limit in MB for CVMFS; leave this blank to
     use the system default (4 GB)
@@ -153,4 +153,3 @@ cvmfsexec will not be used if:
 - /cvmfs is already available via bind-mount
 - `CVMFSEXEC_REPOS` is empty
 - `NO_CVMFSEXEC` is set
-

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ in two ways:
 Note: Supporting Singularity jobs inside the container will require the capabilities
 DAC_OVERRIDE, DAC_READ_SEARCH, SETGID, SETUID, SYS_ADMIN, SYS_CHROOT, and SYS_PTRACE.
 
-Example invocation utilizing a token for authentication:
+Example invocation utilizing a token for authentication and bind-mounting CVMFS:
 
 ```
 docker run -it --rm --user osg \
@@ -94,9 +94,10 @@ CVMFS available by using [cvmfsexec](https://github.com/cvmfs/cvmfsexec#readme).
 
 You will need to specify a list of CVMFS repos to mount in the environment
 variable `CVMFSEXEC_REPOS`.
-This will require a kernel version >= 3.10.0-1127 on an EL7-compatible host
-with user namespaces enabled or >= 4.18 on an EL8-compatible host --
-see the cvmfsexec README linked above for details.
+
+On EL7, you must have kernel version >= 3.10.0-1127 (run `rpm -q kernel` to check),
+and user namespaces enabled.  On EL8, you must have kernel version >= 4.18.
+See the cvmfsexec README linked above for details.
 
 Note that cvmfsexec will not be run if CVMFS repos are already available in
 `/cvmfs` via bind-mount.

--- a/README.md
+++ b/README.md
@@ -136,7 +136,9 @@ You can store the logs outside of the container by bind-mounting a directory to
 
 cvmfsexec requires the additional options `--device=/dev/fuse` and
 `--security-opt=seccomp=unconfined`.  Supporting Singularity jobs when using
-cvmfsexec requires privileged containers (`--privileged`).  Using privileged containers avoids the need for those two additional options and all the `--cap-add` options without adding much risk so it is recommended.
+cvmfsexec requires privileged containers (`--privileged`).  Using privileged
+containers avoids the need for those two additional options and all the
+`--cap-add` options without adding much risk, so it is recommended.
 
 The following example invocation will:
 -   Use a token for authentication

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ docker run -it --rm --user osg \
        --cap-add=DAC_READ_SEARCH \
        --cap-add=SYS_ADMIN --cap-add=SYS_CHROOT --cap-add=SYS_PTRACE \
        -v /cvmfs:/cvmfs:shared \
-       -v /path/to/token:/etc/condor/tokens-orig.d/flock.opensciencegrid.org
+       -v /path/to/token:/etc/condor/tokens-orig.d/flock.opensciencegrid.org \
        -e GLIDEIN_Site="..." \
        -e GLIDEIN_ResourceName="..." \
        -e GLIDEIN_Start_Extra="True" \
@@ -147,7 +147,7 @@ docker run -it --rm --user osg \
        --security-opt=seccomp=unconfined \
        -v /var/cache/cvmfsexec:/cvmfsexec-cache \
        -v /var/log/cvmfsexec:/cvmfsexec-logs \
-       -v /path/to/token:/etc/condor/tokens-orig.d/flock.opensciencegrid.org
+       -v /path/to/token:/etc/condor/tokens-orig.d/flock.opensciencegrid.org \
        -e GLIDEIN_Site="..." \
        -e GLIDEIN_ResourceName="..." \
        -e GLIDEIN_Start_Extra="True" \
@@ -155,4 +155,3 @@ docker run -it --rm --user osg \
        -e CVMFSEXEC_REPOS="oasis.opensciencegrid.org singularity.opensciencegrid.org" \
        opensciencegrid/osgvo-docker-pilot:latest
 ```
-

--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ There are several environment variables you can set for cvmfsexec:
 -   `CVMFS_QUOTA_LIMIT` - the quota limit in MB for CVMFS; leave this blank to
     use the system default (4 GB)
 
+You can add other CVMFS options by bind-mounting a config file over
+`/cvmfsexec/default.local`; note that options in environment variables are preferred
+over options in `/cvmfsexec/default.local`.
 
 You can store the cache outside of the container by bind-mounting a directory
 to `/cvmfs-cache`.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,11 @@ You will need to specify a list of CVMFS repos to mount in the environment
 variable `CVMFSEXEC_REPOS`.
 
 On EL7, you must have kernel version >= 3.10.0-1127 (run `rpm -q kernel` to check),
-and user namespaces enabled.  On EL8, you must have kernel version >= 4.18.
+and user namespaces enabled.  See step 1 in the
+[Singularity Install document](https://opensciencegrid.org/docs/worker-node/install-singularity/#enabling-unprivileged-singularity)
+for details.
+
+On EL8, you must have kernel version >= 4.18.
 See the [cvmfsexec README](https://github.com/cvmfs/cvmfsexec#readme) details.
 
 Note that cvmfsexec will not be run if CVMFS repos are already available in

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ in two ways:
 2. Use cvmfsexec as described in [the cvmfsexec section below](#cvmfs-without-a-bind-mount-using-cvmfsexec).
 
 Note: Supporting Singularity jobs inside the container will require the capabilities
-DAC_OVERRIDE, DAC_READ_SEARCH, SETGID, SETUID, SYS_ADMIN, SYS_CHROOT, and SYS_PTRACE.
+`DAC_OVERRIDE`, `DAC_READ_SEARCH`, `SETGID`, `SETUID`, `SYS_ADMIN`, `SYS_CHROOT`, and `SYS_PTRACE`.
 
 Example invocation utilizing a token for authentication and bind-mounting CVMFS:
 
@@ -97,7 +97,7 @@ variable `CVMFSEXEC_REPOS`.
 
 On EL7, you must have kernel version >= 3.10.0-1127 (run `rpm -q kernel` to check),
 and user namespaces enabled.  On EL8, you must have kernel version >= 4.18.
-See the cvmfsexec README linked above for details.
+See the [cvmfsexec README](https://github.com/cvmfs/cvmfsexec#readme) details.
 
 Note that cvmfsexec will not be run if CVMFS repos are already available in
 `/cvmfs` via bind-mount.

--- a/README.md
+++ b/README.md
@@ -82,8 +82,10 @@ $ singularity build osgvo-pilot.sif docker://opensciencegrid/osgvo-docker-pilot
 If you don't have CVMFS available on the host, the container can still make
 CVMFS available by using [cvmfsexec](https://github.com/cvmfs/cvmfsexec#readme).
 
-This will require a kernel version >= 3.10.0-1127 on an EL7-compatible host with user namespaces enabled
-or >= 4.18 on an EL8-compatible host --
+You will need to specify a list of CVMFS repos to mount in the environment
+variable `CVMFSEXEC_REPOS`.
+This will require a kernel version >= 3.10.0-1127 on an EL7-compatible host
+with user namespaces enabled or >= 4.18 on an EL8-compatible host --
 see the cvmfsexec README linked above for details.
 
 This will also require granting the container some additional privileges, which
@@ -95,7 +97,12 @@ you can do in one of two ways:
     `--security-opt seccomp=unconfined --security-opt systempaths=unconfined --device=/dev/fuse`
     to the `docker run` invocation.
 
-The second option will add only the minimum necessary privileges for cvmfsexec.  You can add additional security to that option by also adding `--security-opt no-new-privileges`.
+The second option will add only the minimum necessary privileges for cvmfsexec.
+You can add additional security to that option by also adding `--security-opt no-new-privileges`.
+If cvmfsexec does not have the required privileges, the container will fail.
+
+Note that cvmfsexec will not be run if CVMFS repos are already available in
+`/cvmfs` via bind-mount.
 
 Using cvmfsexec takes place in the entrypoint, which means it will still happen
 even if you specify a different command to run, such as `bash`.  You can bypass
@@ -105,12 +112,9 @@ clears the command.
 
 There are several environment variables you can set for cvmfsexec:
 
--   `NO_CVMFSEXEC` - set this to any non-empty value to disable cvmfsexec.
-
--   `CVMFSEXEC_REPOS` - this is a comma-separated list of CVMFS repos to mount, if using cvmfsexec.
-    Set this to blank to avoid using cvmfsexec, in which case you won't need to
-    add the above permissions to your container.  The default is to mount the
-    OASIS repo (oasis.opensciencegrid.org).
+-   `CVMFSEXEC_REPOS` - this is a comma-separated list of CVMFS repos to mount,
+    if using cvmfsexec; leave this blank to disable cvmfsexec.
+    OSG jobs frequently use the OASIS repo (`oasis.opensciencegrid.org`).
 
 -   `CVMFS_HTTP_PROXY` - this sets the proxy to use for CVMFS; if left blank
     it will find the best one via WLCG Web Proxy Auto Discovery.
@@ -126,8 +130,8 @@ You can store the logs outside of the container by bind-mounting a directory to
 
 
 Here is an example invocation using a token for authentication, using cvmfsexec
-instead of bind-mounting `/cvmfs`, sending the cache to `/var/cache/cvmfsexec`
-and the logs to `/var/log/cvmfsexec`:
+to mount the OASIS repos instead of bind-mounting `/cvmfs`, sending the cache
+to `/var/cache/cvmfsexec` and the logs to `/var/log/cvmfsexec`:
 
 ```
 docker run -it --rm --user osg \
@@ -144,12 +148,7 @@ docker run -it --rm --user osg \
        -e GLIDEIN_ResourceName="..." \
        -e GLIDEIN_Start_Extra="True" \
        -e OSG_SQUID_LOCATION="..." \
+       -e CVMFSEXEC_REPOS=oasis.opensciencegrid.org \
        opensciencegrid/osgvo-docker-pilot:latest
 ```
 
-
-If cvmfsexec does not have the required privileges, the container will fail.
-cvmfsexec will not be used if:
-- /cvmfs is already available via bind-mount
-- `CVMFSEXEC_REPOS` is empty
-- `NO_CVMFSEXEC` is set

--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ In order to successfully start payload jobs:
 5. Optional: add to the START expression with `GLIDEIN_Start_Extra`. This is useful to limit
    the pilot to only run certain jobs.
 
+In addition, you will be able to run more OSG jobs if you provide CVMFS.  You can do this
+in two ways:
+
+1. Mount CVMFS on the host and bind-mount it into the container by adding `-v /cvmfs:/cvmfs`.
+   This is the preferred mechanism.
+2. Use cvmfsexec as described in [the cvmfsexec section below](#cvmfs-without-a-bind-mount-using-cvmfsexec).
+
 Example invocation utilizing a token for authentication:
 
 ```

--- a/README.md
+++ b/README.md
@@ -98,27 +98,6 @@ This will require a kernel version >= 3.10.0-1127 on an EL7-compatible host
 with user namespaces enabled or >= 4.18 on an EL8-compatible host --
 see the cvmfsexec README linked above for details.
 
-This will also require granting the container some additional privileges, which
-you can do in one of two ways:
-
-1.  Add `--privileged` to the `docker run` invocation.
-
-2.  Add
-    `--security-opt seccomp=unconfined --security-opt systempaths=unconfined --device=/dev/fuse`
-    to the `docker run` invocation.
-
-The first option is simpler and does not require unprivileged user namespaces
-to be enabled, but adds more privileges to the container.
-Using `--privileged` also adds the capabilities listed below for running
-Singularity jobs.
-
-The second option will add only the minimum necessary privileges for cvmfsexec,
-but requires unprivileged user namespaces to be enabled.
-You can add additional security to the second option by also adding
-`--security-opt no-new-privileges`.
-
-If cvmfsexec does not have the required privileges, the container will fail.
-
 Note that cvmfsexec will not be run if CVMFS repos are already available in
 `/cvmfs` via bind-mount.
 
@@ -149,8 +128,7 @@ to `/cvmfs-cache`.
 You can store the logs outside of the container by bind-mounting a directory to
 `/cvmfs-logs`.
 
-Note: Supporting Singularity jobs inside the container will require the capabilities
-DAC_OVERRIDE, DAC_READ_SEARCH, SETGID, SETUID, SYS_ADMIN, SYS_CHROOT, and SYS_PTRACE.
+cvmfsexec requires the additional option `--device=/dev/fuse`.
 
 Here is an example invocation using a token for authentication, using cvmfsexec
 to mount the OASIS repos instead of bind-mounting `/cvmfs`, sending the cache
@@ -162,8 +140,6 @@ docker run -it --rm --user osg \
        --cap-add=DAC_OVERRIDE --cap-add=SETUID --cap-add=SETGID \
        --cap-add=DAC_READ_SEARCH \
        --cap-add=SYS_ADMIN --cap-add=SYS_CHROOT --cap-add=SYS_PTRACE \
-       --security-opt seccomp=unconfined \
-       --security-opt systempaths=unconfined \
        --device=/dev/fuse \
        -v /var/cache/cvmfsexec:/cvmfsexec-cache \
        -v /var/log/cvmfsexec:/cvmfsexec-logs \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,11 +10,14 @@ cvmfsexec_tarball=/cvmfsexec.tar.gz
 cvmfsexec_local_config=$cvmfsexec_root/dist/etc/cvmfs/default.local
 
 if [[ -d /cvmfs/config-osg.opensciencegrid.org ]]; then
-    # OSG CVMFS already available (perhaps via bind-mount),
-    # no special action needed.
+    echo "OSG CVMFS already available (perhaps via bind-mount),"
+    echo "skipping cvmfsexec."
     exec "$@"
 elif [[ -z $CVMFSEXEC_REPOS ]]; then
-    # No CVMFS repos requested, skipping cvmfsexec.
+    echo "No CVMFS repos requested, skipping cvmfsexec."
+    exec "$@"
+elif [[ -n $NO_CVMFSEXEC ]]; then
+    echo "cvmfsexec explicitly disabled."
     exec "$@"
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+shopt -s nullglob
+cvmfs_mounts=(/cvmfs/*)
+if [[ -z $cvmfs_mounts && -d ~/cvmfsexec && -n $CVMFS_REPOS ]]; then
+    # user hasn't bind-mounted /cvmfs; use cvmfsexec instead
+    exec ~/cvmfsexec/cvmfsexec $CVMFS_REPOS -- "$@"
+else
+    exec "$@"
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,11 +3,15 @@
 shopt -s nullglob
 cvmfs_mounts=(/cvmfs/*)
 if [[ -z $cvmfs_mounts && -d /cvmfsexec-template && -n $CVMFSEXEC_REPOS ]]; then
+    set -e
+    echo "No cvmfs mounts, but /cvmfsexec-template exists and caller has requested mounting $CVMFSEXEC_REPOS"
     # user hasn't bind-mounted /cvmfs; use cvmfsexec instead
     # We need our own copy of cvmfsexec for permissions reasons.
     cvmfsexec_root=/tmp/cvmfsexec-$(id -u)
     if [[ ! -d $cvmfsexec_root ]]; then
+        echo "No cvmfsexec dir found for this user at $cvmfsexec_root; creating from template"
         cp -rp /cvmfsexec-template $cvmfsexec_root
+        echo "Fetching OSG CVMFS config"
         $cvmfsexec_root/makedist osg
     fi
     exec $cvmfsexec_root/cvmfsexec $CVMFSEXEC_REPOS -- "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,18 +1,19 @@
 #!/bin/bash
 
+set -x
+
 shopt -s nullglob
 cvmfs_mounts=(/cvmfs/*)
-if [[ -z $cvmfs_mounts && -d /cvmfsexec-template && -n $CVMFSEXEC_REPOS ]]; then
+if [[ -z $cvmfs_mounts && -n $CVMFSEXEC_REPOS && -n $CVMFSEXEC_DIST ]]; then
     set -e
-    echo "No cvmfs mounts, but /cvmfsexec-template exists and caller has requested mounting $CVMFSEXEC_REPOS"
-    # user hasn't bind-mounted /cvmfs; use cvmfsexec instead
+    echo "No cvmfs mounts; using cvmfsexec to mount $CVMFSEXEC_REPOS"
     # We need our own copy of cvmfsexec for permissions reasons.
     cvmfsexec_root=/tmp/cvmfsexec-$(id -u)
     if [[ ! -d $cvmfsexec_root ]]; then
-        echo "No cvmfsexec dir found for this user at $cvmfsexec_root; creating from template"
-        cp -rp /cvmfsexec-template $cvmfsexec_root
-        echo "Fetching OSG CVMFS config"
-        $cvmfsexec_root/makedist osg
+        echo "No cvmfsexec dir found for this user at $cvmfsexec_root; creating one"
+        cp -rp /cvmfsexec $cvmfsexec_root
+        echo "Fetching $CVMFSEXEC_DIST CVMFS config"
+        $cvmfsexec_root/makedist $CVMFSEXEC_DIST
     fi
     exec $cvmfsexec_root/cvmfsexec $CVMFSEXEC_REPOS -- "$@"
 else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,20 +1,24 @@
 #!/bin/bash
 
-set -x
+fail () {
+    echo "$@" >&2
+    exit 1
+}
 
 shopt -s nullglob
 cvmfs_mounts=(/cvmfs/*)
 if [[ -z $cvmfs_mounts && -n $CVMFSEXEC_REPOS && -n $CVMFSEXEC_DIST ]]; then
-    set -e
     echo "No cvmfs mounts; using cvmfsexec to mount $CVMFSEXEC_REPOS"
     # We need our own copy of cvmfsexec for permissions reasons.
     cvmfsexec_root=/tmp/cvmfsexec-$(id -u)
     if [[ ! -d $cvmfsexec_root ]]; then
         echo "No cvmfsexec dir found for this user at $cvmfsexec_root; creating one"
-        cp -rp /cvmfsexec $cvmfsexec_root
+        cp -rp /cvmfsexec $cvmfsexec_root || fail "Couldn't create $cvmfsexec_root"
         echo "Fetching $CVMFSEXEC_DIST CVMFS config"
-        $cvmfsexec_root/makedist $CVMFSEXEC_DIST
+        $cvmfsexec_root/makedist $CVMFSEXEC_DIST || fail "Couldn't fetch CVMFS config"
     fi
+    $cvmfsexec_root/cvmfsexec -- /bin/true || \
+        fail "cvmfsexec smoke test failed.  You may not have the permissions to run cvmfsexec; see https://github.com/cvmfs/cvmfsexec#README for details"
     exec $cvmfsexec_root/cvmfsexec $CVMFSEXEC_REPOS -- "$@"
 else
     exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,9 +16,6 @@ if [[ -d /cvmfs/config-osg.opensciencegrid.org ]]; then
 elif [[ -z $CVMFSEXEC_REPOS ]]; then
     echo "No CVMFS repos requested, skipping cvmfsexec."
     exec "$@"
-elif [[ -n $NO_CVMFSEXEC ]]; then
-    echo "cvmfsexec explicitly disabled."
-    exec "$@"
 fi
 
 cd "$cvmfsexec_root" || \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,9 +2,15 @@
 
 shopt -s nullglob
 cvmfs_mounts=(/cvmfs/*)
-if [[ -z $cvmfs_mounts && -d ~/cvmfsexec && -n $CVMFS_REPOS ]]; then
+if [[ -z $cvmfs_mounts && -d /cvmfsexec-template && -n $CVMFSEXEC_REPOS ]]; then
     # user hasn't bind-mounted /cvmfs; use cvmfsexec instead
-    exec ~/cvmfsexec/cvmfsexec $CVMFS_REPOS -- "$@"
+    # We need our own copy of cvmfsexec for permissions reasons.
+    cvmfsexec_root=/tmp/cvmfsexec-$(id -u)
+    if [[ ! -d $cvmfsexec_root ]]; then
+        cp -rp /cvmfsexec-template $cvmfsexec_root
+        $cvmfsexec_root/makedist osg
+    fi
+    exec $cvmfsexec_root/cvmfsexec $CVMFSEXEC_REPOS -- "$@"
 else
     exec "$@"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,7 +25,7 @@ if [[ ! -e $cvmfsexec_root/dist ]]; then
         fail "Couldn't extract $cvmfsexec_tarball into $cvmfsexec_root"
 fi
 
-$cvmfsexec_root/cvmfsexec -- /bin/true || \
+$cvmfsexec_root/cvmfsexec -N -- /bin/true || \
     fail "cvmfsexec smoke test failed.  You may not have the permissions to run cvmfsexec; see https://github.com/cvmfs/cvmfsexec#README for details"
 
 add_or_replace () {
@@ -53,4 +53,4 @@ if [[ -n $CVMFS_QUOTA_LIMIT ]]; then
 fi
 
 
-exec $cvmfsexec_root/cvmfsexec $CVMFSEXEC_REPOS -- "$@"
+exec $cvmfsexec_root/cvmfsexec -N $CVMFSEXEC_REPOS -- "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,6 +40,10 @@ add_or_replace () {
     fi
 }
 
+if [[ -e /cvmfsexec/default.local ]]; then
+    cp -f /cvmfsexec/default.local "$cvmfsexec_local_config"
+fi
+
 if [[ -n $CVMFS_HTTP_PROXY ]]; then
     add_or_replace "$cvmfsexec_local_config" CVMFS_HTTP_PROXY "${CVMFS_HTTP_PROXY}"
 fi


### PR DESCRIPTION
- Use cvmfsexec to mount CVMFS repos if needed
- Don't run crond (doesn't work as non-root)
- Create log files before tailing them to solve "<FILE> has been replaced witha remote file" error from tail
