### PR TITLE
Start expression fixups

### DIFF
--- a/50-main.config
+++ b/50-main.config
@@ -51,9 +51,7 @@ GLIDEIN_ResourceName = "Docker"
 STARTD_ATTRS = $(STARTD_ATTRS) GLIDEIN_Country GLIDEIN_Site GLIDEIN_ResourceName WorkerGroupName IsOsgVoContainer
 
 # only accept new work for a while, for validated nodes and jobs with project name set
-# the QDate is do shield from a OSGConnect upgrade and can be removed after 1/1/21
-START = (TARGET.QDate >= 1605631000) && \
-        (isUndefined(DaemonStartTime) || (CurrentTime - DaemonStartTime) < (MY.ACCEPT_JOBS_FOR_HOURS*60*60)) && \
+START = (isUndefined(DaemonStartTime) || (CurrentTime - DaemonStartTime) < (MY.ACCEPT_JOBS_FOR_HOURS*60*60)) && \
         (MY.OSG_NODE_VALIDATED == True) && \
         (!isUndefined(TARGET.ProjectName)) && \
         (isUndefined(MY.RecentJobStarts) || MY.RecentJobStarts < 400) && \

--- a/50-main.config
+++ b/50-main.config
@@ -51,7 +51,7 @@ GLIDEIN_ResourceName = "Docker"
 STARTD_ATTRS = $(STARTD_ATTRS) GLIDEIN_Country GLIDEIN_Site GLIDEIN_ResourceName WorkerGroupName IsOsgVoContainer
 
 # only accept new work for a while, for validated nodes and jobs with project name set
-START = (isUndefined(DaemonStartTime) || (CurrentTime - DaemonStartTime) < (MY.ACCEPT_JOBS_FOR_HOURS*60*60)) && \
+START = (isUndefined(DaemonStartTime) || (time() - DaemonStartTime) < (MY.ACCEPT_JOBS_FOR_HOURS*60*60)) && \
         (MY.OSG_NODE_VALIDATED == True) && \
         (!isUndefined(TARGET.ProjectName)) && \
         (isUndefined(MY.RecentJobStarts) || MY.RecentJobStarts < 400) && \


### PR DESCRIPTION
Noticed these when troubleshooting Chameleon cloud's idle slots. Perhaps related: Lancium is also seeing their backfill containers sitting idle.

@rynge what sets `MY.OSG_NODE_VALIDATED`? It doesn't appear to be set in the Chameleon container or one of the JetStream containers:

```
$ podman run --rm -it opensciencegrid/hosted-ce:release condor_status -pool flock.opensciencegrid.org -const '!isUndefined(IsOsgVoContainer) && isUndefined(osg_node_validated)' -af name
slot1@JetStream-1858bc205145
slot1@chameleon-uc-dev-backfill-383906f438aa
```