### PR TITLE
Mount /cvmfs with :shared; without it, the host can't see automounted volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ docker run -it --rm --user osg \
        --cap-add=DAC_OVERRIDE --cap-add=SETUID --cap-add=SETGID \
        --cap-add=CAP_DAC_READ_SEARCH \
        --cap-add=SYS_ADMIN --cap-add=SYS_CHROOT --cap-add=SYS_PTRACE \
-       -v /cvmfs:/cvmfs \
+       -v /cvmfs:/cvmfs:shared \
        -e TOKEN="..." \
        -e GLIDEIN_Site="..." \
        -e GLIDEIN_ResourceName="..." \


### PR DESCRIPTION
@DrDaveD says not having this might cause issues.