### PR TITLE
allow CCB port range to be configurable

### DIFF
--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -65,7 +65,13 @@ export _CONDOR_SEC_PASSWORD_DIRECTORY=$LOCAL_DIR/condor/passwords.d
 
 # extra HTCondor config
 # pick one ccb port and stick with it for the lifetime of the glidein
-CCB_PORT=$(python -S -c "import random; print random.randrange(9700,9899)")
+if [ "x$CCB_RANGE_LOW" = "x" ]; then
+    export CCB_RANGE_LOW=9700
+fi
+if [ "x$CCB_RANGE_HIGH" = "x" ]; then
+    export CCB_RANGE_LOW=9899
+fi
+CCB_PORT=$(python -S -c "import random; print random.randrange($CCB_RANGE_LOW,$CCB_RANGE_HIGH+1)")
 NETWORK_HOSTNAME="$(echo $GLIDEIN_ResourceName | sed 's/_/-/g')-$(hostname)"
 
 # to avoid collisions when ~ is shared, write the config file to /tmp

--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -69,7 +69,7 @@ if [ "x$CCB_RANGE_LOW" = "x" ]; then
     export CCB_RANGE_LOW=9700
 fi
 if [ "x$CCB_RANGE_HIGH" = "x" ]; then
-    export CCB_RANGE_LOW=9899
+    export CCB_RANGE_HIGH=9899
 fi
 CCB_PORT=$(python -S -c "import random; print random.randrange($CCB_RANGE_LOW,$CCB_RANGE_HIGH+1)")
 NETWORK_HOSTNAME="$(echo $GLIDEIN_ResourceName | sed 's/_/-/g')-$(hostname)"


### PR DESCRIPTION
Add two environment variables to the setup script allowing dynamic configuration of the CCB port range.  

This is very useful for running against another collector, and can be used with
```
CCB_RANGE_LOW=9618
CCB_RANGE_HIGH=9618
```
to connect to a "default" collector without multiple CCBs configured.

Note: I'm assuming the default range should be [9700, 9899] inclusive.  It was written before as [9700, 9899) exclusive.