### PR TITLE
Don't use /tmp as the local directory

### DIFF
--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -34,7 +34,7 @@ if [ "x$ANNEX_NAME" = "x" ]; then
     export ANNEX_NAME="$GLIDEIN_ResourceName@$GLIDEIN_Site"
 fi
 
-LOCAL_DIR=$(mktemp -d /tmp/osgvo-pilot-XXXXXX)
+LOCAL_DIR=$(mktemp -d /pilot/osgvo-pilot-XXXXXX)
 mkdir -p "$LOCAL_DIR"/condor/tokens.d
 mkdir -p "$LOCAL_DIR"/condor/passwords.d
 chmod 700 "$LOCAL_DIR"/condor/passwords.d

--- a/50-main.config
+++ b/50-main.config
@@ -9,7 +9,7 @@ CCB_HEARTBEAT_INTERVAL = 120
 FILESYSTEM_DOMAIN = $(HOSTNAME)
 UID_DOMAIN = $(HOSTNAME)
 
-LOCAL_DIR=/tmp/condor_local
+LOCAL_DIR=/pilot/condor_local
 SPOOL = $(LOCAL_DIR)/spool
 LOG = $(LOCAL_DIR)/log
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,6 @@ COPY 50-main.config /etc/condor/config.d/
  
 RUN chown -R osg: ~osg 
 
-WORKDIR /tmp
+RUN mkdir -p /pilot && chmod 1777 /pilot
+
+WORKDIR /pilot


### PR DESCRIPTION
Use /pilot instead of /tmp as the directory for putting all pilot-related stuff into; it's  chmodded 1777, just like /tmp, so ownership isn't a problem.

Tested this on tiger -- everything seems to start up successfully, but is there a way I can do further validation?
