### PR TITLE
Delete any whitespace in CVMFSEXEC_REPOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,6 @@ docker run -it --rm --user osg \
        -e GLIDEIN_ResourceName="..." \
        -e GLIDEIN_Start_Extra="True" \
        -e OSG_SQUID_LOCATION="..." \
-       -e CVMFSEXEC_REPOS="oasis.opensciencegrid.org singularity.opensciencegrid.org" \
+       -e CVMFSEXEC_REPOS="oasis.opensciencegrid.org,singularity.opensciencegrid.org" \
        opensciencegrid/osgvo-docker-pilot:latest
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,6 +9,9 @@ cvmfsexec_root=/cvmfsexec
 cvmfsexec_tarball=/cvmfsexec.tar.gz
 cvmfsexec_local_config=$cvmfsexec_root/dist/etc/cvmfs/default.local
 
+# Delete any whitespace in CVMFSEXEC_REPOS
+CVMFSEXEC_REPOS=$(tr -d $' \t\n' <<<"$CMFSEXEC_REPOS")
+
 if [[ -d /cvmfs/config-osg.opensciencegrid.org ]]; then
     echo "OSG CVMFS already available (perhaps via bind-mount),"
     echo "skipping cvmfsexec."


### PR DESCRIPTION
This lets the user declare the repo list on multiple indented lines like
```
docker run ... \
     -e CVMFSEXEC_REPOS="
            repo1,
            repo2,
            repo3" \
    ...
```
