### PR TITLE
shut down an idle pilot

### DIFF
--- a/10-htcondor.conf
+++ b/10-htcondor.conf
@@ -1,6 +1,6 @@
 [program:condor_master]
 command=/usr/sbin/condor_master_wrapper
-autorestart=True
+autorestart=unexpected
 startsecs=60
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0

--- a/10-htcondor.conf
+++ b/10-htcondor.conf
@@ -1,6 +1,6 @@
 [program:condor_master]
 command=/usr/sbin/condor_master_wrapper
-autorestart=unexpected
+autorestart=True
 startsecs=60
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0

--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -9,7 +9,7 @@ fi
 
 
 #
-# Taken from creation/web_base/condor_startup.sh in the gwms 
+# Taken from creation/web_base/condor_startup.sh in the gwms
 # Set a variable read from a file
 #
 pstr='"'
@@ -111,6 +111,9 @@ fi
 if [ "x$ACCEPT_JOBS_FOR_HOURS" = "x" ]; then
     export ACCEPT_JOBS_FOR_HOURS=336
 fi
+if [ "x$ACCEPT_IDLE_MINUTES" = "x" ]; then
+    export ACCEPT_IDLE_MINUTES=30
+fi
 if [ "x$ANNEX_NAME" = "x" ]; then
     export ANNEX_NAME="$GLIDEIN_ResourceName@$GLIDEIN_Site"
 fi
@@ -181,12 +184,12 @@ GLIDEIN_ResourceName = "$GLIDEIN_ResourceName"
 OSG_SQUID_LOCATION = "$OSG_SQUID_LOCATION"
 
 ACCEPT_JOBS_FOR_HOURS = $ACCEPT_JOBS_FOR_HOURS
+ACCEPT_IDLE_MINUTES = $ACCEPT_IDLE_MINUTES
 
 AnnexName = "$ANNEX_NAME"
 
-STARTD_ATTRS = \$(STARTD_ATTRS) AnnexName ACCEPT_JOBS_FOR_HOURS
-MASTER_ATTRS = \$(MASTER_ATTRS) AnnexName ACCEPT_JOBS_FOR_HOURS
-
+STARTD_ATTRS = \$(STARTD_ATTRS) AnnexName ACCEPT_JOBS_FOR_HOURS ACCEPT_IDLE_MINUTES
+MASTER_ATTRS = \$(MASTER_ATTRS) AnnexName ACCEPT_JOBS_FOR_HOURS ACCEPT_IDLE_MINUTES
 
 # policy
 use policy : Hold_If_Memory_Exceeded
@@ -233,7 +236,7 @@ cd $LOCAL_DIR
 
 # gwms files in the correct location
 cp -a /gwms/* .
-mkdir -p .gwms.d/bin 
+mkdir -p .gwms.d/bin
 for target in cleanup  postjob  prejob  setup  setup_singularity; do
     mkdir -p .gwms.d/exec/$target
 done

--- a/50-main.config
+++ b/50-main.config
@@ -69,7 +69,7 @@ include ifexist: $ENV(PILOT_CONFIG_FILE)
 #
 
 # when the work is complete, shut down the startd
-STARTD_NOCLAIM_SHUTDOWN = 30 * 60
+STARTD_NOCLAIM_SHUTDOWN = $(ACCEPT_IDLE_MINUTES) * 60
 
 # Have the master exit if the startd isn't around and it's been given more
 # than sixty seconds to show up.  (We could avoid having a timeout if we

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,7 @@ fail () {
 cvmfsexec_root=/cvmfsexec
 cvmfsexec_tarball=/cvmfsexec.tar.gz
 cvmfsexec_local_config=$cvmfsexec_root/dist/etc/cvmfs/default.local
+htcondor_supervisord_config=/etc/supervisord.d/10-htcondor.conf
 
 if [[ -d /cvmfs/config-osg.opensciencegrid.org ]]; then
     echo "OSG CVMFS already available (perhaps via bind-mount),"
@@ -34,6 +35,18 @@ add_or_replace () {
     local value="$3"
 
     if grep -Eq "^${var}=" "$file"; then
+        sed -i -r -e "s#^${var}=.*#${var}=${value}#" "$file"
+    else
+        echo "${var}=\"${value}\"" >> "$file"
+    fi
+}
+
+add_or_replace_quoted () {
+    local file="$1"
+    local var="$2"
+    local value="$3"
+
+    if grep -Eq "^${var}=" "$file"; then
         sed -i -r -e "s#^${var}=.*#${var}=\"${value}\"#" "$file"
     else
         echo "${var}=\"${value}\"" >> "$file"
@@ -45,12 +58,15 @@ if [[ -e /cvmfsexec/default.local ]]; then
 fi
 
 if [[ -n $CVMFS_HTTP_PROXY ]]; then
-    add_or_replace "$cvmfsexec_local_config" CVMFS_HTTP_PROXY "${CVMFS_HTTP_PROXY}"
+    add_or_replace_quoted "$cvmfsexec_local_config" CVMFS_HTTP_PROXY "${CVMFS_HTTP_PROXY}"
 fi
 
 if [[ -n $CVMFS_QUOTA_LIMIT ]]; then
-    add_or_replace "$cvmfsexec_local_config" CVMFS_QUOTA_LIMIT "${CVMFS_QUOTA_LIMIT}"
+    add_or_replace_quoted "$cvmfsexec_local_config" CVMFS_QUOTA_LIMIT "${CVMFS_QUOTA_LIMIT}"
 fi
 
+if [ "x$SUPERVISORD_RESTART_POLICY" != "x" ]; then
+    add_or_replace "$htcondor_supervisord_config" autorestart "${SUPERVISORD_RESTART_POLICY}"
+fi
 
 exec $cvmfsexec_root/cvmfsexec -N $CVMFSEXEC_REPOS -- "$@"


### PR DESCRIPTION
Currently `STARTD_NOCLAIM_SHUTDOWN` is fixed at 30 minutes, and supervisord restarts condor repeatedly, never exiting the container.

This PR allows the idle time to be configured, and shuts down the container if `condor_master` exits normally.