### PR TITLE
Ensure that Nvidia libs are bind mounted into child containers

### DIFF
--- a/10-ldconfig-cache.sh
+++ b/10-ldconfig-cache.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Rebuild the ld.so cache for Singularity child containers (SOFTWARE-4807)
+ldconfig "$LD_LIBRARY_PATH"

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,11 @@ ENV NUM_CPUS=
 # Amount of memory (in MB) available to jobs
 ENV MEMORY=
 
+# Ensure that GPU libs can be accessed by user Singularity containers
+# running inside Singularity osgvo-docker-pilot containers
+# (SOFTWARE-4807)
+COPY ldconfig_wrapper.sh /usr/local/bin/ldconfig
+COPY 10-ldconfig-cache.sh /etc/osg/image-init.d/
 
 COPY entrypoint.sh /bin/entrypoint.sh
 COPY 10-setup-htcondor.sh /etc/osg/image-init.d/

--- a/ldconfig_wrapper.sh
+++ b/ldconfig_wrapper.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/sbin/ldconfig -C /pilot/ld.so.cache "$@"


### PR DESCRIPTION
(SOFTWARE-4807)

Work around for https://github.com/hpcng/singularity/issues/5759, courtesy of @DrDaveD 

We do this to ensure that GPU libs can be accessed by user containers.
In particular, the backfill container mounts the libs from the host to
'/.singularity.d/libs' (available in LD_LIBRARY_PATH).

ldconfig tries to write its cache to /etc/, which isn't possible if
the outer backfill container is started up with Singularity.