### PR TITLE
Revert reduced caps for Docker + CVMFSEXEC

### DIFF
--- a/tests/test_inside_gha.sh
+++ b/tests/test_inside_gha.sh
@@ -5,10 +5,6 @@ OSP_TOKEN_PATH=/tmp/token
 COMMON_DOCKER_ARGS="run --user osg
                         --detach
                         --security-opt apparmor=unconfined
-                        --security-opt seccomp=unconfined
-                        --security-opt systempaths=unconfined
-                        --security-opt no-new-privileges
-                        --net=host
                         --name backfill
                         -v $OSP_TOKEN_PATH:/etc/condor/tokens-orig.d/flock.opensciencegrid.org
                         -e GLIDEIN_Site='None'
@@ -170,13 +166,16 @@ CONTAINER_RUNTIME="$1"
 CVMFS_INSTALL="$2"
 case "$CVMFS_INSTALL" in
     bindmount)
-        DOCKER_EXTRA_ARGS=(-v "/cvmfs:/cvmfs:shared")
+        DOCKER_EXTRA_ARGS=(--security-opt seccomp=unconfined
+                           --security-opt systempaths=unconfined
+                           --security-opt no-new-privileges
+                           -v "/cvmfs:/cvmfs:shared")
         install_cvmfs
         start_cvmfs
         ;;
     cvmfsexec)
-        DOCKER_EXTRA_ARGS=(-e CVMFSEXEC_REPOS='oasis.opensciencegrid.org singularity.opensciencegrid.org'
-                           --device=/dev/fuse)
+        DOCKER_EXTRA_ARGS=(--privileged
+                           -e CVMFSEXEC_REPOS='oasis.opensciencegrid.org singularity.opensciencegrid.org')
         ;;
 esac
 


### PR DESCRIPTION
We'd rather use --privileged instead of --net=host

This reverts commits 175ca6a..e96cf70