### PR TITLE
Log *all* condor logs to stdout

### DIFF
--- a/10-rsyslogd.conf
+++ b/10-rsyslogd.conf
@@ -9,3 +9,6 @@ stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
+# Lower priority means its started first / shut down last
+# We want to have logging working for when condor starts.
+priority=100

--- a/10-rsyslogd.conf
+++ b/10-rsyslogd.conf
@@ -1,7 +1,6 @@
 
 [program:rsyslogd]
 directory=/
-#command=rsyslogd -n -i /tmp/rsyslog.pid
 command=/usr/bin/launch_rsyslogd
 autorestart=true
 stdout_logfile=/proc/self/fd/3

--- a/10-rsyslogd.conf
+++ b/10-rsyslogd.conf
@@ -1,0 +1,11 @@
+
+[program:rsyslogd]
+directory=/
+#command=rsyslogd -n -i /tmp/rsyslog.pid
+command=/usr/bin/launch_rsyslogd
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+

--- a/10-rsyslogd.conf
+++ b/10-rsyslogd.conf
@@ -4,9 +4,9 @@ directory=/
 #command=rsyslogd -n -i /tmp/rsyslog.pid
 command=/usr/bin/launch_rsyslogd
 autorestart=true
-stdout_logfile=/dev/stdout
+stdout_logfile=/proc/self/fd/3
 stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
+stderr_logfile=/proc/self/fd/4
 stderr_logfile_maxbytes=0
 
 # Lower priority means its started first / shut down last

--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -155,7 +155,7 @@ export _CONDOR_SEC_PASSWORD_DIRECTORY=$LOCAL_DIR/condor/passwords.d
 
 # Setup syslog server
 mkdir -p /pilot/{log,log/log,rsyslog,rsyslog/pid,rsyslog/workdir,rsyslog/conf}
-touch /pilot/log/{Master,Start,Proc,log/Starter}Log /pilot/log/StarterLog{,.testing}
+touch /pilot/log/{Master,Start,Proc,SharedPort,XferStatsLog,log/Starter}Log /pilot/log/StarterLog{,.testing}
 
 # Configure remote peer if applicable
 if [[ "x$SYSLOG_HOST" != "x" ]]; then

--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -155,7 +155,7 @@ export _CONDOR_SEC_PASSWORD_DIRECTORY=$LOCAL_DIR/condor/passwords.d
 
 # Setup syslog server
 mkdir -p /pilot/{log,log/log,rsyslog,rsyslog/pid,rsyslog/workdir,rsyslog/conf}
-touch /pilot/log/{Master,Start,Proc,SharedPort,XferStatsLog,log/Starter}Log /pilot/log/StarterLog{,.testing}
+touch /pilot/log/{Master,Start,Proc,SharedPort,XferStats,log/Starter}Log /pilot/log/StarterLog{,.testing}
 
 # Configure remote peer if applicable
 if [[ "x$SYSLOG_HOST" != "x" ]]; then

--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -154,8 +154,45 @@ export _CONDOR_SEC_PASSWORD_FILE=$LOCAL_DIR/condor/tokens.d/flock.opensciencegri
 export _CONDOR_SEC_PASSWORD_DIRECTORY=$LOCAL_DIR/condor/passwords.d
 
 # Setup syslog server
-mkdir -p /pilot/{log,rsyslog,rsyslog-pid}
+mkdir -p /pilot/{log,log/log,rsyslog,rsyslog/pid,rsyslog/workdir,rsyslog/conf}
+touch /pilot/log/{Master,Start,Proc,log/Starter}Log /pilot/log/StarterLog{,.testing}
+
+# Configure remote peer if applicable
+if [[ "x$SYSLOG_HOST" != "x" ]]; then
+
 generate-hostcert "$_CONDOR_SEC_PASSWORD_FILE" || :
+
+for NAME in Condor RSYSLOG Supervisord
+do
+
+cat >> /pilot/rsyslog/conf/forward.conf << EOF
+ruleset(name="forward${NAME}") {
+  action(type="omfwd"
+    queue.filename="fwdAll"
+    queue.maxdiskspace="100m"
+    queue.saveonshutdown="off"
+    queue.type="LinkedList"
+    action.resumeRetryCount="10"
+    StreamDriverMode="1"
+    StreamDriver="gtls"
+    StreamDriverAuthMode="x509/name"
+    Target="$SYSLOG_HOST" Port="6514" Protocol="tcp"
+    template="${NAME}_SyslogProtocol23Format"
+  )
+}
+EOF
+
+done
+
+else
+
+cat > /pilot/rsyslog/conf/forward.conf << EOF
+ruleset(name="forwardCondor") {}
+ruleset(name="forwardRSYSLOG") {}
+ruleset(name="forwardSupervisord") {}
+EOF
+
+fi
 
 # extra HTCondor config
 # if CCB_RANGE_* is set, use the old config, otherwise assume OSPool with shared port

--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -154,6 +154,7 @@ export _CONDOR_SEC_PASSWORD_FILE=$LOCAL_DIR/condor/tokens.d/flock.opensciencegri
 export _CONDOR_SEC_PASSWORD_DIRECTORY=$LOCAL_DIR/condor/passwords.d
 
 # Setup syslog server
+mkdir -p /pilot/{log,rsyslog,rsyslog-pid}
 generate-hostcert "$_CONDOR_SEC_PASSWORD_FILE" || :
 
 # extra HTCondor config

--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -153,6 +153,9 @@ set -x
 export _CONDOR_SEC_PASSWORD_FILE=$LOCAL_DIR/condor/tokens.d/flock.opensciencegrid.org
 export _CONDOR_SEC_PASSWORD_DIRECTORY=$LOCAL_DIR/condor/passwords.d
 
+# Setup syslog server
+generate-hostcert "$_CONDOR_SEC_PASSWORD_FILE" || :
+
 # extra HTCondor config
 # if CCB_RANGE_* is set, use the old config, otherwise assume OSPool with shared port
 if [[ "x$CCB_RANGE_LOW" != "x" ]]; then

--- a/50-main.config
+++ b/50-main.config
@@ -1,6 +1,4 @@
 DAEMON_LIST = MASTER, STARTD
-USE_SHARED_PORT = False
-AUTO_INCLUDE_SHARED_PORT_IN_DAEMON_LIST = False
 
 CONDOR_HOST = cm-1.ospool.osg-htc.org,cm-2.ospool.osg-htc.org
 USE_CCB = True

--- a/50-main.config
+++ b/50-main.config
@@ -11,7 +11,7 @@ UID_DOMAIN = $(HOSTNAME)
 
 LOCAL_DIR=/pilot/condor_local
 SPOOL = $(LOCAL_DIR)/spool
-LOG = $(LOCAL_DIR)/log
+LOG = /pilot/log
 
 # now dynamically set in 10-setup-htcondor.sh
 #USER_JOB_WRAPPER = /usr/sbin/osgvo-singularity-wrapper
@@ -85,5 +85,7 @@ IsOsgVoContainer = True
 # All daemons should log to syslog instead of to their corresponding files.  In this
 # container, syslog is configured to echo all logs to stdout (which the container runtime
 # should pick up).
-LOG_TO_SYSLOG = True
-
+MAX_DEFAULT_LOG = 0
+LOGS_USE_TIMESTAMP = true
+ALL_DEBUG=D_CAT,D_SUB_SECOND,D_PID
+STARTER_LOG_NAME_APPEND = false

--- a/50-main.config
+++ b/50-main.config
@@ -82,3 +82,8 @@ MASTER.DAEMON_SHUTDOWN_FAST = ( STARTD_StartTime == 0 ) && ((CurrentTime - Daemo
 # Identify pilot container jobs for gratia-probe detection
 IsOsgVoContainer = True
 
+# All daemons should log to syslog instead of to their corresponding files.  In this
+# container, syslog is configured to echo all logs to stdout (which the container runtime
+# should pick up).
+LOG_TO_SYSLOG = True
+

--- a/50-main.config
+++ b/50-main.config
@@ -86,6 +86,4 @@ IsOsgVoContainer = True
 # container, syslog is configured to echo all logs to stdout (which the container runtime
 # should pick up).
 MAX_DEFAULT_LOG = 0
-#LOGS_USE_TIMESTAMP = true
 ALL_DEBUG=D_CAT,D_SUB_SECOND,D_PID
-STARTER_LOG_NAME_APPEND = false

--- a/50-main.config
+++ b/50-main.config
@@ -86,6 +86,6 @@ IsOsgVoContainer = True
 # container, syslog is configured to echo all logs to stdout (which the container runtime
 # should pick up).
 MAX_DEFAULT_LOG = 0
-LOGS_USE_TIMESTAMP = true
+#LOGS_USE_TIMESTAMP = true
 ALL_DEBUG=D_CAT,D_SUB_SECOND,D_PID
 STARTER_LOG_NAME_APPEND = false

--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,10 @@ RUN mkdir -p /pilot && chmod 1777 /pilot
 
 COPY --from=compile /launch_rsyslogd /usr/bin/launch_rsyslogd
 RUN chmod 04755 /usr/bin/launch_rsyslogd && \
-    mkdir -p /etc/pki/rsyslog && chmod 01777 /etc/pki/rsyslog
+    mkdir -p /etc/pki/rsyslog && chmod 01777 /etc/pki/rsyslog && \
+    ln -sf /usr/share/zoneinfo/UTC /etc/localtime
+
+COPY supervisord_startup.sh /usr/local/sbin/
 
 WORKDIR /pilot
 # We need an ENTRYPOINT so we can use cvmfsexec with any command (such as bash for debugging purposes)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
+ARG BASE_YUM_REPO=testing
+
 FROM alpine:latest AS compile
 COPY launch_rsyslogd.c /tmp/launch_rsyslogd.c
 RUN apk --no-cache add gcc musl-dev && \
  cc -static -o /launch_rsyslogd /tmp/launch_rsyslogd.c && \
  strip /launch_rsyslogd
-
-ARG BASE_YUM_REPO=testing
 
 FROM opensciencegrid/software-base:3.6-el7-${BASE_YUM_REPO}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,6 @@ RUN useradd osg \
         singularity \
         attr \
         git \
-        gcc \
         rsyslog rsyslog-gnutls python36-cryptography python36-requests \
  && yum clean all \
  && mkdir -p /etc/condor/passwords.d /etc/condor/tokens.d

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN useradd osg \
         attr \
         git \
         gcc \
-        rsyslog rsyslog-gnutls \
+        rsyslog rsyslog-gnutls python36-cryptography python36-requests \
  && yum clean all \
  && mkdir -p /etc/condor/passwords.d /etc/condor/tokens.d
 
@@ -89,7 +89,7 @@ ENV MEMORY=
 COPY ldconfig_wrapper.sh /usr/local/bin/ldconfig
 COPY 10-ldconfig-cache.sh /etc/osg/image-init.d/
 
-COPY entrypoint.sh /bin/entrypoint.sh
+COPY generate-hostcert entrypoint.sh /bin/
 COPY 10-setup-htcondor.sh /etc/osg/image-init.d/
 COPY 10-cleanup-htcondor.sh /etc/osg/image-cleanup.d/
 COPY 10-htcondor.conf 10-rsyslogd.conf /etc/supervisord.d/
@@ -110,7 +110,8 @@ RUN chown -R osg: ~osg
 RUN mkdir -p /pilot && chmod 1777 /pilot
 
 COPY launch_rsyslogd.c /tmp/launch_rsyslogd.c
-RUN gcc /tmp/launch_rsyslogd.c -o /usr/bin/launch_rsyslogd && rm /tmp/launch_rsyslogd.c && chmod 04755 /usr/bin/launch_rsyslogd
+RUN gcc /tmp/launch_rsyslogd.c -o /usr/bin/launch_rsyslogd && rm /tmp/launch_rsyslogd.c && chmod 04755 /usr/bin/launch_rsyslogd && \
+    mkdir -p /etc/pki/rsyslog && chmod 01777 /etc/pki/rsyslog
 
 WORKDIR /pilot
 # We need an ENTRYPOINT so we can use cvmfsexec with any command (such as bash for debugging purposes)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,9 @@
+FROM alpine:latest AS compile
+COPY launch_rsyslogd.c /tmp/launch_rsyslogd.c
+RUN apk --no-cache add gcc musl-dev && \
+ cc -static -o /launch_rsyslogd /tmp/launch_rsyslogd.c && \
+ strip /launch_rsyslogd
+
 ARG BASE_YUM_REPO=testing
 
 FROM opensciencegrid/software-base:3.6-el7-${BASE_YUM_REPO}
@@ -109,8 +115,8 @@ RUN chown -R osg: ~osg
 
 RUN mkdir -p /pilot && chmod 1777 /pilot
 
-COPY launch_rsyslogd.c /tmp/launch_rsyslogd.c
-RUN gcc /tmp/launch_rsyslogd.c -o /usr/bin/launch_rsyslogd && rm /tmp/launch_rsyslogd.c && chmod 04755 /usr/bin/launch_rsyslogd && \
+COPY --from=compile /launch_rsyslogd /usr/bin/launch_rsyslogd
+RUN chmod 04755 /usr/bin/launch_rsyslogd && \
     mkdir -p /etc/pki/rsyslog && chmod 01777 /etc/pki/rsyslog
 
 WORKDIR /pilot

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ RUN useradd osg \
         singularity \
         attr \
         git \
+        gcc \
+        rsyslog rsyslog-gnutls \
  && yum clean all \
  && mkdir -p /etc/condor/passwords.d /etc/condor/tokens.d
 
@@ -90,8 +92,9 @@ COPY 10-ldconfig-cache.sh /etc/osg/image-init.d/
 COPY entrypoint.sh /bin/entrypoint.sh
 COPY 10-setup-htcondor.sh /etc/osg/image-init.d/
 COPY 10-cleanup-htcondor.sh /etc/osg/image-cleanup.d/
-COPY 10-htcondor.conf /etc/supervisord.d/
+COPY 10-htcondor.conf 10-rsyslogd.conf /etc/supervisord.d/
 COPY 50-main.config /etc/condor/config.d/
+COPY rsyslog.conf /etc/
 RUN chmod 755 /bin/entrypoint.sh
 
 RUN if [[ -n $TIMESTAMP ]]; then \
@@ -105,6 +108,9 @@ RUN if [[ -n $TIMESTAMP ]]; then \
 RUN chown -R osg: ~osg 
 
 RUN mkdir -p /pilot && chmod 1777 /pilot
+
+COPY launch_rsyslogd.c /tmp/launch_rsyslogd.c
+RUN gcc /tmp/launch_rsyslogd.c -o /usr/bin/launch_rsyslogd && rm /tmp/launch_rsyslogd.c && chmod 04755 /usr/bin/launch_rsyslogd
 
 WORKDIR /pilot
 # We need an ENTRYPOINT so we can use cvmfsexec with any command (such as bash for debugging purposes)

--- a/condor_master_wrapper
+++ b/condor_master_wrapper
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-tail -F `condor_config_val LOG`/MasterLog `condor_config_val LOG`/StartLog 2>/dev/null &
+#tail -F `condor_config_val LOG`/MasterLog `condor_config_val LOG`/StartLog 2>/dev/null &
 
 exec /usr/sbin/condor_master -f
 

--- a/condor_master_wrapper
+++ b/condor_master_wrapper
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-#tail -F `condor_config_val LOG`/MasterLog `condor_config_val LOG`/StartLog 2>/dev/null &
 
 exec /usr/sbin/condor_master -f
 

--- a/generate-hostcert
+++ b/generate-hostcert
@@ -39,6 +39,7 @@ with open(sys.argv[1], "rb") as fp:
 
 response = requests.post("https://os-registry.osgdev.chtc.io/syslog-ca/issue", data={"csr": csr_bytes},
     headers={"Authorization": f"Bearer {token.decode()}"},
+    timeout=20,
 )
 
 response_dict = response.json()

--- a/generate-hostcert
+++ b/generate-hostcert
@@ -1,0 +1,53 @@
+#!/usr/bin/python3
+
+import os
+import sys
+import json
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.backends import default_backend
+
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+from cryptography.hazmat.primitives import hashes
+
+import requests
+
+# First, generate a new host key.
+key = rsa.generate_private_key(
+    public_exponent=65537,
+    key_size=2048,
+    backend=default_backend(),
+)
+
+key_bytes = key.private_bytes(
+    encoding=serialization.Encoding.PEM,
+    format=serialization.PrivateFormat.TraditionalOpenSSL,
+    encryption_algorithm=serialization.NoEncryption()
+)
+
+csr = x509.CertificateSigningRequestBuilder(
+   ).subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, u"will_be_overwritten")])
+   ).sign(key, hashes.SHA256(), backend=default_backend())
+
+
+csr_bytes = csr.public_bytes(serialization.Encoding.PEM).decode()
+
+with open(sys.argv[1], "rb") as fp:
+    token = fp.read().strip()
+
+response = requests.post("https://os-registry.osgdev.chtc.io/syslog-ca/issue", data={"csr": csr_bytes},
+    headers={"Authorization": f"Bearer {token.decode()}"},
+)
+
+response_dict = response.json()
+response_dict["key"] = key_bytes.decode()
+
+os.makedirs("/etc/pki/rsyslog", exist_ok=True)
+with open("/etc/pki/rsyslog/ca.crt", "w") as fp:
+    fp.write(response_dict["ca"])
+with open("/etc/pki/rsyslog/tls.crt", "w") as fp:
+    fp.write(response_dict["certificate"])
+with open("/etc/pki/rsyslog/tls.key", "w") as fp:
+    fp.write(response_dict["key"])

--- a/generate-hostcert
+++ b/generate-hostcert
@@ -38,7 +38,7 @@ with open(sys.argv[1], "rb") as fp:
     token = fp.read().strip()
 
 try:
-    response = requests.post("https://os-registry.osgdev.chtc.io/syslog-ca/issue", data={"csr": csr_bytes},
+    response = requests.post("https://os-registry.opensciencegrid.org/syslog-ca/issue", data={"csr": csr_bytes},
         headers={"Authorization": f"Bearer {token.decode()}"},
         timeout=20,
     )

--- a/generate-hostcert
+++ b/generate-hostcert
@@ -37,12 +37,20 @@ csr_bytes = csr.public_bytes(serialization.Encoding.PEM).decode()
 with open(sys.argv[1], "rb") as fp:
     token = fp.read().strip()
 
-response = requests.post("https://os-registry.osgdev.chtc.io/syslog-ca/issue", data={"csr": csr_bytes},
-    headers={"Authorization": f"Bearer {token.decode()}"},
-    timeout=20,
-)
-
-response_dict = response.json()
+try:
+    response = requests.post("https://os-registry.osgdev.chtc.io/syslog-ca/issue", data={"csr": csr_bytes},
+        headers={"Authorization": f"Bearer {token.decode()}"},
+        timeout=20,
+    )
+except OSError as err:
+    print("*** Error downloading certificate from registry: %s" % err, file=sys.stderr)
+    raise
+try:
+    response_dict = response.json()
+except ValueError as err:
+    print("*** Bad data received from registry: %s" % err, file=sys.stderr)
+    print("*** Received data: %s", response, file=sys.stderr)
+    raise
 response_dict["key"] = key_bytes.decode()
 
 os.makedirs("/etc/pki/rsyslog", exist_ok=True)

--- a/launch_rsyslogd.c
+++ b/launch_rsyslogd.c
@@ -2,5 +2,5 @@
 
 int main(int argc, char *argv[])
 {
-    return execl("/usr/sbin/rsyslogd", "rsyslogd", "-n", NULL);
+    return execl("/usr/sbin/rsyslogd", "rsyslogd", "-n", "-i", "/pilot/rsyslog-pid/pid", NULL);
 }

--- a/launch_rsyslogd.c
+++ b/launch_rsyslogd.c
@@ -2,5 +2,5 @@
 
 int main(int argc, char *argv[])
 {
-    return execl("/usr/sbin/rsyslogd", "rsyslogd", "-n", "-i", "/pilot/rsyslog-pid/pid", NULL);
+    return execl("/usr/sbin/rsyslogd", "rsyslogd", "-n", "-i", "/pilot/rsyslog/pid/pid", NULL);
 }

--- a/launch_rsyslogd.c
+++ b/launch_rsyslogd.c
@@ -1,0 +1,6 @@
+#include <unistd.h>
+
+int main(int argc, char *argv[])
+{
+    return execl("/usr/sbin/rsyslogd", "rsyslogd", "-n", NULL);
+}

--- a/rsyslog.conf
+++ b/rsyslog.conf
@@ -15,11 +15,35 @@ SysSock.UsePIDFromSystem="on"
 # Look for condor logfiles
 module(
 load="imfile"
+PollingInterval="1"
 )
 
 # Where to place auxiliary files
-global(workDirectory="/pilot/rsyslog")
+global(workDirectory="/pilot/rsyslog/workdir")
 
+
+template(name="Supervisord_SyslogProtocol23Format" type="list")
+{
+    constant(value="<")
+    property(name="pri")
+    constant(value=">1 ")
+    property(name="$.date")
+    constant(value="T")
+    property(name="$.time")
+    constant(value="Z ")
+    property(name="hostname")
+    constant(value=" ")
+    property(name="app-name")
+    constant(value=" 1 - [level=\"")
+    property(name="$.level")
+    constant(value="\"] ")
+    property(name="msg"
+             regex.type="ERE"
+             regex.expression="(^[[:digit:][:space:]TZ:,-]+ [[:upper:]]+) (.*)"
+             regex.submatch="2"
+            )
+    constant(value="\n")
+}
 
 # Condor-specific logging format
 template(name="Condor_SyslogProtocol23Format" type="list")
@@ -27,28 +51,33 @@ template(name="Condor_SyslogProtocol23Format" type="list")
     constant(value="<")
     property(name="pri")
     constant(value=">1 ")
-    property(name="timestamp"
-             dateFormat="rfc3339")
-    constant(value=" ")
+    property(name="$.year")
+    constant(value="-")
+    property(name="$.month")
+    constant(value="-")
+    property(name="$.day")
+    constant(value="T")
+    property(name="$.hour")
+    constant(value=":")
+    property(name="$.min")
+    constant(value=":")
+    property(name="$.sec")
+    constant(value="Z ")
     property(name="hostname")
     constant(value=" ")
     property(name="app-name")
     constant(value=" ")
     property(name="msg"
              regex.type="ERE"
-             regex.expression="(^[[:digit:]]+\\.[[:digit:]]+ \\(pid\\:([[:digit:]]+)\\))"
+             regex.expression="(^[[:digit:][:space:]/:.]+ \\(pid\\:([[:digit:]]+)\\))"
              regex.submatch="2"
             )
-    constant(value=" - [cat=\"")
+    constant(value=" - [")
+    property(name="$.structure")
+    constant(value="] ")
     property(name="msg"
              regex.type="ERE"
-             regex.expression="(^[[:digit:]]+\\.[[:digit:]]+ \\(pid\\:[[:digit:]]+\\) \\(D_([[:upper:]_]+)\\))"
-             regex.submatch="2"
-            )
-    constant(value="\"] ")
-    property(name="msg"
-             regex.type="ERE"
-             regex.expression="(^[[:digit:]]+\\.[[:digit:]]+ \\(pid\\:[[:digit:]]+\\) \\(D_[[:upper:]_]+\\)) (.*)"
+             regex.expression="(^[[:digit:][:space:]/:.]+ \\(pid\\:[[:digit:]]+\\) \\(D_[[:upper:]_]+\\)) (.*)"
              regex.submatch="2"
             )
     constant(value="\n")
@@ -60,8 +89,18 @@ template(name="Proc_SyslogProtocol23Format" type="list")
     constant(value="<")
     property(name="pri")
     constant(value=">1 ")
-    property(name="timestamp"
-             dateFormat="rfc3339")
+    property(name="$.year")
+    constant(value="-")
+    property(name="$.month")
+    constant(value="-")
+    property(name="$.day")
+    constant(value="T")
+    property(name="$.hour")
+    constant(value=":")
+    property(name="$.min")
+    constant(value=":")
+    property(name="$.sec")
+    constant(value="Z ")
     constant(value=" ")
     property(name="hostname")
     constant(value=" ")
@@ -75,32 +114,65 @@ template(name="Proc_SyslogProtocol23Format" type="list")
     constant(value="\n")
 }
 
+ruleset(name="CondorTimestamp") {
+  set $.year = "20" & field(field($msg, 32, 1), 47, 3);
+  set $.month = field($msg, 47, 1);
+  set $.day = field($msg, 47, 2);
+
+  set $.time = field($msg, 32, 2);
+  set $.hour = field($.time, 58, 1);
+  set $.min = field($.time, 58, 2);
+  set $.sec = field($.time, 58, 3);
+}
 
 ruleset(name="ProcLog") {
+  call CondorTimestamp
   action(type="omfile" file="/dev/stdout"
          template="Proc_SyslogProtocol23Format"
         )
 }
 
-ruleset(name="CondorLog") {
+ruleset(name="SupervisordLog") {
+
+  set $.date = field($msg, 32, 1);
+  set $.time = replace(field($msg, 32, 2), ",", ".");
+  set $.level = field($msg, 32, 3);
+
   action(type="omfile" file="/dev/stdout"
-         template="Condor_SyslogProtocol23Format"
+         template="Supervisord_SyslogProtocol23Format"
         )
 
-  action(type="omfwd"
-    queue.filename="fwdAll"
-    queue.maxdiskspace="100m"
-    queue.saveonshutdown="off"
-    queue.type="LinkedList"
-    action.resumeRetryCount="10"
-    StreamDriverMode="1"
-    StreamDriver="gtls"
-    StreamDriverAuthMode="x509/name"
-    Target="syslog.osgdev.chtc.io" Port="6514" Protocol="tcp"
-  )
+  call forwardSupervisord
+}
+
+ruleset(name="CondorLog") {
+
+  call CondorTimestamp
+
+  set $.extra!cat = replace(replace(field($msg, 32, 4), "(", ""), ")", "");
+  if ($.extra!slot != "") then {
+    set $.structure = "cat=\"" & $.extra!cat & "\" slot=\"" & $.extra!slot & "\"";
+  } else {
+    set $.structure = "cat=\"" & $.extra!cat & "\"";
+  }
+
+  action(type="omfile" file="/dev/stdout"
+        template="Condor_SyslogProtocol23Format"
+        )
+
+  call forwardCondor
+}
+
+ruleset(name="StarterLog") {
+  set $.extra!slot = field($!metadata!filename, 46, 2);
+
+  call CondorLog
 }
 
 module(load="builtin:omfile" Template="RSYSLOG_SyslogProtocol23Format")
+
+# Alternate configuration locations
+$IncludeConfig /pilot/rsyslog/conf/*.conf
 
 input(
 type="imfile"
@@ -108,7 +180,7 @@ File="/pilot/log/MasterLog"
 Tag="condor_master"
 Facility="local2"
 Severity="info"
-startmsg.regex="(^[[:digit:]]+\\.[[:digit:]]+ \\(pid)"
+startmsg.regex="(^[[:digit:][:space:]/:.]+ \\(pid)"
 ruleset="CondorLog"
 )
 
@@ -117,17 +189,18 @@ type="imfile"
 File="/pilot/log/StartLog"
 Tag="condor_startd"
 Facility="local2"
-startmsg.regex="(^[[:digit:]]+\\.[[:digit:]]+ \\(pid)"
+startmsg.regex="(^[[:digit:][:space:]/:.]+ \\(pid)"
 ruleset="CondorLog"
 )
 
 input(
 type="imfile"
-File="/pilot/log/StarterLog.testing"
+File="/pilot/log/StarterLog.*"
 Tag="condor_starter"
 Facility="local2"
-startmsg.regex="(^[[:digit:]]+\\.[[:digit:]]+ \\(pid)"
-ruleset="CondorLog"
+startmsg.regex="(^[[:digit:][:space:]/:.]+ \\(pid)"
+addMetadata="on"
+ruleset="StarterLog"
 )
 
 input(
@@ -135,7 +208,7 @@ type="imfile"
 File="/pilot/log/StarterLog"
 Tag="condor_starter"
 Facility="local2"
-startmsg.regex="^[[:digit:]]+\\.[[:digit:]]+ \\(D_"
+startmsg.regex="(^[[:digit:][:space:]/:.]+ \\(pid)"
 ruleset="CondorLog"
 )
 
@@ -144,7 +217,7 @@ type="imfile"
 File="/pilot/log/log/StarterLog"
 Tag="condor_starter"
 Facility="local2"
-startmsg.regex="^[[:digit:]]+\\.[[:digit:]]+ \\(D_"
+startmsg.regex="(^[[:digit:][:space:]/:.]+ \\(pid)"
 ruleset="CondorLog"
 )
 
@@ -156,17 +229,23 @@ Facility="local2"
 ruleset="ProcLog"
 )
 
+input(
+type="imfile"
+File="/pilot/log/supervisord.log"
+Tag="supervisord"
+Facility="daemon"
+ruleset="SupervisordLog"
+)
+
+input(
+type="imfile"
+File="/tmp/startup.log"
+Tag="startup"
+Facility="user"
+ruleset="forwardRSYSLOG"
+)
+
 # Log all messages to the syslog daemon's stdout.
 *.* /dev/stdout
 
-*.* action(type="omfwd"
-    queue.filename="fwdAll"
-    queue.maxdiskspace="100m"
-    queue.saveonshutdown="off"
-    queue.type="LinkedList"
-    action.resumeRetryCount="10"
-    StreamDriverMode="1"
-    StreamDriver="gtls"
-    StreamDriverAuthMode="x509/name"
-    Target="syslog.osgdev.chtc.io" Port="6514" Protocol="tcp")
-
+call forwardRSYSLOG

--- a/rsyslog.conf
+++ b/rsyslog.conf
@@ -1,3 +1,9 @@
+global(
+DefaultNetstreamDriver="gtls"
+DefaultNetstreamDriverCAFile="/etc/pki/rsyslog/ca.crt"
+DefaultNetstreamDriverCertFile="/etc/pki/rsyslog/tls.crt"
+DefaultNetstreamDriverKeyFile="/etc/pki/rsyslog/tls.key"
+)
 
 # Listen to the traditional syslog Unix socket.
 module(
@@ -14,3 +20,14 @@ module(load="builtin:omfile" Template="RSYSLOG_TraditionalFileFormat")
 
 # Log all messages to the syslog daemon's stdout.
 *.* /dev/stdout
+
+*.* action(type="omfwd"
+    queue.filename="fwdAll"
+    queue.maxdiskspace="100m"
+    queue.saveonshutdown="off"
+    queue.type="LinkedList"
+    action.resumeRetryCount="10"
+    StreamDriverMode="1"
+    StreamDriver="gtls"
+    StreamDriverAuthMode="x509/name"
+    Target="syslog.osgdev.chtc.io" Port="6514" Protocol="tcp")

--- a/rsyslog.conf
+++ b/rsyslog.conf
@@ -1,0 +1,16 @@
+
+# Listen to the traditional syslog Unix socket.
+module(
+load="imuxsock"
+SysSock.Unlink="off"
+SysSock.UsePIDFromSystem="on"
+)
+
+# Where to place auxiliary files
+global(workDirectory="/var/lib/rsyslog")
+
+# Use default timestamp format
+module(load="builtin:omfile" Template="RSYSLOG_TraditionalFileFormat")
+
+# Log all messages to the syslog daemon's stdout.
+*.* /dev/stdout

--- a/rsyslog.conf
+++ b/rsyslog.conf
@@ -12,11 +12,149 @@ SysSock.Unlink="off"
 SysSock.UsePIDFromSystem="on"
 )
 
-# Where to place auxiliary files
-global(workDirectory="/var/lib/rsyslog")
+# Look for condor logfiles
+module(
+load="imfile"
+)
 
-# Use default timestamp format
-module(load="builtin:omfile" Template="RSYSLOG_TraditionalFileFormat")
+# Where to place auxiliary files
+global(workDirectory="/pilot/rsyslog")
+
+
+# Condor-specific logging format
+template(name="Condor_SyslogProtocol23Format" type="list")
+{
+    constant(value="<")
+    property(name="pri")
+    constant(value=">1 ")
+    property(name="timestamp"
+             dateFormat="rfc3339")
+    constant(value=" ")
+    property(name="hostname")
+    constant(value=" ")
+    property(name="app-name")
+    constant(value=" ")
+    property(name="msg"
+             regex.type="ERE"
+             regex.expression="(^[[:digit:]]+\\.[[:digit:]]+ \\(pid\\:([[:digit:]]+)\\))"
+             regex.submatch="2"
+            )
+    constant(value=" - [cat=\"")
+    property(name="msg"
+             regex.type="ERE"
+             regex.expression="(^[[:digit:]]+\\.[[:digit:]]+ \\(pid\\:[[:digit:]]+\\) \\(D_([[:upper:]_]+)\\))"
+             regex.submatch="2"
+            )
+    constant(value="\"] ")
+    property(name="msg"
+             regex.type="ERE"
+             regex.expression="(^[[:digit:]]+\\.[[:digit:]]+ \\(pid\\:[[:digit:]]+\\) \\(D_[[:upper:]_]+\\)) (.*)"
+             regex.submatch="2"
+            )
+    constant(value="\n")
+}
+
+
+template(name="Proc_SyslogProtocol23Format" type="list")
+{
+    constant(value="<")
+    property(name="pri")
+    constant(value=">1 ")
+    property(name="timestamp"
+             dateFormat="rfc3339")
+    constant(value=" ")
+    property(name="hostname")
+    constant(value=" ")
+    property(name="app-name")
+    constant(value=" - - - ")
+    property(name="msg"
+             regex.type="ERE"
+             regex.expression="(^[[:digit:]]{2}/[[:digit:]]{2}/[[:digit:]]{2} [[:digit:]]{2}\\:[[:digit:]]{2}\\:[[:digit:]]{2} \\: (.*))"
+             regex.submatch="2"
+            )
+    constant(value="\n")
+}
+
+
+ruleset(name="ProcLog") {
+  action(type="omfile" file="/dev/stdout"
+         template="Proc_SyslogProtocol23Format"
+        )
+}
+
+ruleset(name="CondorLog") {
+  action(type="omfile" file="/dev/stdout"
+         template="Condor_SyslogProtocol23Format"
+        )
+
+  action(type="omfwd"
+    queue.filename="fwdAll"
+    queue.maxdiskspace="100m"
+    queue.saveonshutdown="off"
+    queue.type="LinkedList"
+    action.resumeRetryCount="10"
+    StreamDriverMode="1"
+    StreamDriver="gtls"
+    StreamDriverAuthMode="x509/name"
+    Target="syslog.osgdev.chtc.io" Port="6514" Protocol="tcp"
+  )
+}
+
+module(load="builtin:omfile" Template="RSYSLOG_SyslogProtocol23Format")
+
+input(
+type="imfile"
+File="/pilot/log/MasterLog"
+Tag="condor_master"
+Facility="local2"
+Severity="info"
+startmsg.regex="(^[[:digit:]]+\\.[[:digit:]]+ \\(pid)"
+ruleset="CondorLog"
+)
+
+input(
+type="imfile"
+File="/pilot/log/StartLog"
+Tag="condor_startd"
+Facility="local2"
+startmsg.regex="(^[[:digit:]]+\\.[[:digit:]]+ \\(pid)"
+ruleset="CondorLog"
+)
+
+input(
+type="imfile"
+File="/pilot/log/StarterLog.testing"
+Tag="condor_starter"
+Facility="local2"
+startmsg.regex="(^[[:digit:]]+\\.[[:digit:]]+ \\(pid)"
+ruleset="CondorLog"
+)
+
+input(
+type="imfile"
+File="/pilot/log/StarterLog"
+Tag="condor_starter"
+Facility="local2"
+startmsg.regex="^[[:digit:]]+\\.[[:digit:]]+ \\(D_"
+ruleset="CondorLog"
+)
+
+input(
+type="imfile"
+File="/pilot/log/log/StarterLog"
+Tag="condor_starter"
+Facility="local2"
+startmsg.regex="^[[:digit:]]+\\.[[:digit:]]+ \\(D_"
+ruleset="CondorLog"
+)
+
+input(
+type="imfile"
+File="/pilot/log/ProcLog"
+Tag="condor_procd"
+Facility="local2"
+ruleset="ProcLog"
+)
 
 # Log all messages to the syslog daemon's stdout.
 *.* /dev/stdout
@@ -31,3 +169,4 @@ module(load="builtin:omfile" Template="RSYSLOG_TraditionalFileFormat")
     StreamDriver="gtls"
     StreamDriverAuthMode="x509/name"
     Target="syslog.osgdev.chtc.io" Port="6514" Protocol="tcp")
+

--- a/rsyslog.conf
+++ b/rsyslog.conf
@@ -214,8 +214,17 @@ ruleset="CondorLog"
 
 input(
 type="imfile"
-File="/pilot/log/log/StarterLog"
+File="/pilot/log/XferStatsLog"
 Tag="condor_starter"
+Facility="local2"
+startmsg.regex="(^[[:digit:][:space:]/:.]+ \\(pid)"
+ruleset="CondorLog"
+)
+
+input(
+type="imfile"
+File="/pilot/log/SharedPortLog"
+Tag="condor_shared_port"
 Facility="local2"
 startmsg.regex="(^[[:digit:][:space:]/:.]+ \\(pid)"
 ruleset="CondorLog"

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,6 +1,6 @@
 [supervisord]
 nodaemon=true
-logfile=/dev/null
+logfile=/pilot/log/supervisord.log
 logfile_maxbytes=0
 
 [unix_http_server]

--- a/supervisord_startup.sh
+++ b/supervisord_startup.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Save current stdout/err to FD 3&4.  Combine FD 1&2.
+# Start a subshell to pipe all the output to a logfile
+exec 3>&1 4>&2 &> >(tee -a /tmp/startup.log)
+
+# Allow the derived images to run any additional runtime customizations
+shopt -s nullglob
+for x in /etc/osg/image-init.d/*.sh; do source "$x"; done
+shopt -u nullglob
+
+# Allow child images to add cleanup customizations
+function source_cleanup {
+    for x in /etc/osg/image-cleanup.d/*.sh; do source "$x"; done
+}
+trap source_cleanup EXIT TERM QUIT
+
+chmod go-w /etc/cron.*/* 2>/dev/null || :
+
+# Restore stdout and err to the FD we stored in FD 3&4.
+exec 1>&3 2>&4
+sleep 1
+
+# Now we can actually start the supervisor
+# Note the original stdout / err are still available as fd 3 & 4.  rsyslog will
+# only log to the latter set.
+exec /usr/bin/supervisord -c /etc/supervisord.conf &> /pilot/log/supervisord.log

--- a/supervisord_startup.sh
+++ b/supervisord_startup.sh
@@ -11,7 +11,9 @@ shopt -u nullglob
 
 # Allow child images to add cleanup customizations
 function source_cleanup {
+    shopt -s nullglob
     for x in /etc/osg/image-cleanup.d/*.sh; do source "$x"; done
+    shopt -u nullglob
 }
 trap source_cleanup EXIT TERM QUIT
 

--- a/tests/test_inside_gha.sh
+++ b/tests/test_inside_gha.sh
@@ -99,7 +99,7 @@ function wait_for_output {
 function test_docker_startup {
     print_test_header "Testing container startup"
 
-    logfile=$(wait_for_output 600 run_inside_backfill_container find /pilot -name StartLog -size 1)
+    logfile=$(wait_for_output 600 run_inside_backfill_container find /pilot -name StartLog -size +1)
     if [[ -z $logfile ]]; then
         debug_docker_backfill
         return 1

--- a/tests/test_inside_gha.sh
+++ b/tests/test_inside_gha.sh
@@ -111,7 +111,7 @@ function test_docker_startup {
                         -- \
                         'Changing activity: Benchmarking -> Idle' \
                         $logfile \
-        || return 1
+        || (tail -n 400 $logfile && return 1)
 }
 
 function test_docker_HAS_SINGULARITY {
@@ -141,7 +141,7 @@ function test_singularity_startup {
                     -- \
                     'Changing activity: Benchmarking -> Idle' \
                     $logfile \
-        || return 1
+        || (tail -n 400 $logfile && return 1)
 }
 
 function test_singularity_HAS_SINGULARITY {

--- a/tests/test_inside_gha.sh
+++ b/tests/test_inside_gha.sh
@@ -131,7 +131,7 @@ function test_docker_HAS_SINGULARITY {
 function test_singularity_startup {
     print_test_header "Testing container startup"
 
-    logfile=$(wait_for_output 600 find $PILOT_DIR -name StartLog -size 1)
+    logfile=$(wait_for_output 600 find $PILOT_DIR -name StartLog -size +1)
     if [[ -z $logfile ]]; then
         cat $SINGULARITY_OUTPUT
     fi

--- a/tests/test_inside_gha.sh
+++ b/tests/test_inside_gha.sh
@@ -99,7 +99,7 @@ function wait_for_output {
 function test_docker_startup {
     print_test_header "Testing container startup"
 
-    logfile=$(wait_for_output 600 run_inside_backfill_container find /pilot -name StartLog)
+    logfile=$(wait_for_output 600 run_inside_backfill_container find /pilot -name StartLog -size 1)
     if [[ -z $logfile ]]; then
         debug_docker_backfill
         return 1
@@ -131,7 +131,7 @@ function test_docker_HAS_SINGULARITY {
 function test_singularity_startup {
     print_test_header "Testing container startup"
 
-    logfile=$(wait_for_output 600 find $PILOT_DIR -name StartLog)
+    logfile=$(wait_for_output 600 find $PILOT_DIR -name StartLog -size 1)
     if [[ -z $logfile ]]; then
         cat $SINGULARITY_OUTPUT
     fi


### PR DESCRIPTION
This (a) adds a syslog daemon to the container (via a setuid binary
as syslog is immovably at `/dev/log`) and (b) tells all HTCSS daemons
to log to the container.

The syslog daemon is set to log to the supervisord stdout, resulting
in all HTCondor logs getting to the container's stdout in a timely
manner.