### PR TITLE
Allow the container to better manage the token registry hostname.

### DIFF
--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -160,7 +160,20 @@ touch /pilot/log/{Master,Start,Proc,SharedPort,XferStats,log/Starter}Log /pilot/
 # Configure remote peer if applicable
 if [[ "x$SYSLOG_HOST" != "x" ]]; then
 
-generate-hostcert "$_CONDOR_SEC_PASSWORD_FILE" || :
+# Set some reasonable defaults for the token registry.
+if [[ "x$REGISTRY_HOST" != "x" ]]; then
+    REGISTRY_HOSTNAME="$REGISTRY_HOST"
+elif [[ "$SYSLOG_HOST" == "syslog.osgdev.chtc.io" ]]; then
+    REGISTRY_HOSTNAME="os-registry.osgdev.chtc.io"
+else
+    REGISTRY_HOSTNAME="os-registry.opensciencegrid.org"
+fi
+
+# If hostcert generation fails, then we'll just skip the whole syslog thing.
+generate-hostcert "$_CONDOR_SEC_PASSWORD_FILE" "$REGISTRY_HOSTNAME" || SYSLOG_HOST=""
+fi
+
+if [[ "x$SYSLOG_HOST" != "x" ]]; then
 
 for NAME in Condor RSYSLOG Supervisord
 do

--- a/generate-hostcert
+++ b/generate-hostcert
@@ -37,8 +37,13 @@ csr_bytes = csr.public_bytes(serialization.Encoding.PEM).decode()
 with open(sys.argv[1], "rb") as fp:
     token = fp.read().strip()
 
+if len(sys.argv) > 2:
+    registry_hostname = sys.argv[2]
+else:
+    registry_hostname = "os-registry.opensciencegrid.org"
+
 try:
-    response = requests.post("https://os-registry.opensciencegrid.org/syslog-ca/issue", data={"csr": csr_bytes},
+    response = requests.post(f"https://{registry_hostname}/syslog-ca/issue", data={"csr": csr_bytes},
         headers={"Authorization": f"Bearer {token.decode()}"},
         timeout=20,
     )


### PR DESCRIPTION
- The sysadmin can override the registry hostname with the `REGISTRY_HOSTNAME` environment variable.
- If the known osgdev syslog server is used, automatically switch to the osgdev token registry.