### PR TITLE
Make regexp more permissive.

### DIFF
--- a/rsyslog.conf
+++ b/rsyslog.conf
@@ -86,7 +86,7 @@ template(name="Condor_SyslogProtocol23Format" type="list")
     constant(value="\"] ")
     property(name="msg"
              regex.type="ERE"
-             regex.expression="(^[[:digit:][:space:]/:.]+ \\(pid\\:[[:digit:]]+\\) \\(D_[[:upper:]_]+\\)) (.*)"
+             regex.expression="(^[[:digit:][:space:]/:.]+ \\(pid\\:[[:digit:]]+\\) \\(D_[[:upper:]_|]+\\)) (.*)"
              regex.submatch="2"
             )
     constant(value="\n")


### PR DESCRIPTION
On failures (and in a few other situations), HTCondor will log categories along the lines of `(D_ALWAYS|D_FAILURE)`; add the pipe character (`|`) to the regexp to account for this situation.