### PR TITLE
Use the single-binary stashcp as stash_plugin

### DIFF
--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -331,13 +331,6 @@ GLIDECLIENT_GROUP_WORK_DIR $PWD/client_group_main
 EOF
 touch $condor_vars_file
 
-# grab the latests copy of stashcp
-mkdir -p client
-
-if (curl --silent --fail --location --connect-timeout 30 --speed-limit 1024 -o client/stashcp http://stash.osgconnect.net/public/dweitzel/stashcp/current/stashcp) &>/dev/null; then
-    chmod 755 client/stashcp
-fi
-
 # test stashcp and add the plugin
 if stashcp /osgconnect/public/dweitzel/stashcp/test.file /tmp/stashcp-test.file >/dev/null; then
     rm -f /tmp/stashcp-test.file

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN curl -sSfL -o /usr/sbin/osgvo-default-image https://raw.githubusercontent.co
 COPY condor_master_wrapper /usr/sbin/
 RUN chmod 755 /usr/sbin/condor_master_wrapper
 
-RUN curl -sSfL -o /usr/libexec/condor/stash_plugin https://raw.githubusercontent.com/opensciencegrid/osg-flock/master/stashcp/stash_plugin \
+RUN cp /gwms/client/stashcp /usr/libexec/condor/stash_plugin \
  && chmod 755 /usr/libexec/condor/stash_plugin
 
 # Override the software-base supervisord.conf to throw away supervisord logs


### PR DESCRIPTION
This is a copy, not a symlink, because the program uses argv[0] to determine its behavior.