### PR TITLE
ITB backfill container (SOFTWARE-5002)

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -24,6 +24,12 @@ jobs:
     strategy:
       matrix:
         repo: ['development', 'testing', 'release']
+        itb: ['', '-itb']
+        exclude:
+          - itb: '-itb'
+            repo: 'release'
+          - itb: '-itb'
+            repo: 'testing'
 
     steps:
     - name: checkout osgvo-docker-pilot
@@ -33,11 +39,11 @@ jobs:
       uses: actions/cache@v2
       with:
         path: /tmp/.buildx-cache
-        key: ${{ matrix.repo }}-buildx-${{ github.sha }}-${{ github.run_id }}
+        key: ${{ matrix.repo }}${{ matrix.itb }}-buildx-${{ github.sha }}-${{ github.run_id }}
         # allow cache hits from previous runs of the current branch,
         # parent branch, then upstream branches, in that order
         restore-keys: |
-          ${{ matrix.repo }}-buildx-
+          ${{ matrix.repo }}${{ matrix.itb }}-buildx-
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
@@ -50,6 +56,7 @@ jobs:
         build-args: |
           BASE_YUM_REPO=${{ matrix.repo }}
           TIMESTAMP=${{ needs.make-date-tag.outputs.dtag }}
+          ITB=${{ matrix.itb }}
         cache-to: type=local,mode=max,dest=/tmp/.buildx-cache
 
   test:
@@ -59,11 +66,16 @@ jobs:
       fail-fast: false
       matrix:
         repo: ['development', 'testing', 'release']
+        itb: ['', '-itb']
         runtime: ['docker', 'singularity']
         cvmfs: ['bindmount', 'cvmfsexec']
         exclude:
           - runtime: singularity
             cvmfs: cvmfsexec
+          - itb: '-itb'
+            repo: 'release'
+          - itb: '-itb'
+            repo: 'testing'
     steps:
       - name: checkout osgvo-docker-pilot
         uses: actions/checkout@v2
@@ -72,7 +84,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ matrix.repo }}-buildx-${{ github.sha }}-${{ github.run_id }}
+          key: ${{ matrix.repo }}${{ matrix.itb }}-buildx-${{ github.sha }}-${{ github.run_id }}
 
       - name: Load osgvo-docker-pilot image
         uses: docker/build-push-action@v2.2.2
@@ -80,6 +92,7 @@ jobs:
           build-args: |
             BASE_YUM_REPO=${{ matrix.repo }}
             TIMESTAMP=${{ needs.make-date-tag.outputs.dtag }}
+            ITB=${{ matrix.itb }}
           load: true  # allow access to built images through the Docker CLI
           tags: osgvo-docker-pilot:latest
           cache-from: type=local,src=/tmp/.buildx-cache
@@ -97,6 +110,12 @@ jobs:
     strategy:
       matrix:
         repo: ['development', 'testing', 'release']
+        itb: ['', '-itb']
+        exclude:
+          - itb: '-itb'
+            repo: 'release'
+          - itb: '-itb'
+            repo: 'testing'
     steps:
       - name: checkout osgvo-docker-pilot
         uses: actions/checkout@v2
@@ -105,17 +124,18 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ matrix.repo }}-buildx-${{ github.sha }}-${{ github.run_id }}
+          key: ${{ matrix.repo }}${{ matrix.itb }}-buildx-${{ github.sha }}-${{ github.run_id }}
 
       - id: generate-tag-list
         env:
           REPO: ${{ matrix.repo }}
           TIMESTAMP: ${{ needs.make-date-tag.outputs.dtag }}
+          ITB: ${{ matrix.itb }}
         run: |
           docker_repo=${GITHUB_REPOSITORY/brianhlin\/docker-/brianhlin/}
           tag_list=()
           for registry in hub.opensciencegrid.org docker.io; do
-            for image_tag in "$REPO" "$REPO-$TIMESTAMP"; do
+            for image_tag in "$REPO$ITB" "$REPO$ITB-$TIMESTAMP"; do
               tag_list+=("$registry/$docker_repo":"$image_tag")
             done
           done

--- a/50-main.config
+++ b/50-main.config
@@ -1,5 +1,6 @@
 DAEMON_LIST = MASTER, STARTD
 
+# CONDOR_HOST may be overridden by the pilot config file
 CONDOR_HOST = cm-1.ospool.osg-htc.org,cm-2.ospool.osg-htc.org
 USE_CCB = True
 CCB_HEARTBEAT_INTERVAL = 120

--- a/Dockerfile
+++ b/Dockerfile
@@ -118,7 +118,7 @@ COPY rsyslog.conf /etc/
 RUN chmod 755 /bin/entrypoint.sh
 
 RUN if [[ -n $TIMESTAMP ]]; then \
-       tag=opensciencegrid/osgvo-docker-pilot:${BASE_YUM_REPO}-${TIMESTAMP}; \
+       tag=opensciencegrid/osgvo-docker-pilot:${BASE_YUM_REPO}${ITB+-itb}-${TIMESTAMP}; \
     else \
        tag=; \
     fi; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -119,6 +119,13 @@ RUN if [[ -n $TIMESTAMP ]]; then \
     sed -i "s|@CONTAINER_TAG@|$tag|" \
            /etc/condor/config.d/50-main.config
 
+RUN \
+    if [[ -n $ITB ]]; then \
+        echo 'Is_ITB_Site = True'  >> /etc/condor/config.d/55-itb.config; \
+        echo 'STARTD_ATTRS = $(STARTD_ATTRS) Is_ITB_Site'  >> /etc/condor/config.d/55-itb.config; \
+        echo 'START = $(START) && (TARGET.ITB_Sites =?= True)'  >> /etc/condor/config.d/55-itb.config; \
+    fi
+
 RUN chown -R osg: ~osg 
 
 RUN mkdir -p /pilot && chmod 1777 /pilot

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,9 +38,7 @@ RUN mkdir -p /gwms/main /gwms/client /gwms/client_group_main /gwms/.gwms.d/bin /
  && curl -sSfL -o /gwms/main/singularity_setup.sh https://raw.githubusercontent.com/glideinWMS/glideinwms/branch_v3_9/creation/web_base/singularity_setup.sh \
  && curl -sSfL -o /gwms/main/singularity_wrapper.sh https://raw.githubusercontent.com/glideinWMS/glideinwms/branch_v3_9/creation/web_base/singularity_wrapper.sh \
  && curl -sSfL -o /gwms/main/singularity_lib.sh https://raw.githubusercontent.com/glideinWMS/glideinwms/branch_v3_9/creation/web_base/singularity_lib.sh \
- && curl -sSfL -o /gwms/client/stashcp https://github.com/opensciencegrid/osg-flock/raw/master/stashcp/stashcp \
- && chmod 755 /gwms/*.sh /gwms/main/*.sh /gwms/client/stashcp \
- && ln -s /gwms/client/stashcp /usr/bin/stashcp
+ && chmod 755 /gwms/*.sh /gwms/main/*.sh
 
 # osgvo scripts
 # Set ITB to use itb versions of all the pilot scripts and join the ITB pool
@@ -56,6 +54,9 @@ RUN git clone --branch ${OSG_FLOCK_BRANCH} https://github.com/${OSG_FLOCK_REPO} 
  && install job-wrappers/${ITB:+itb-}default_singularity_wrapper.sh     /usr/sbin/osgvo-singularity-wrapper \
  && install node-check/${ITB:+itb-}ospool-lib                           /gwms/client_group_main/ospool-lib \
  && install node-check/${ITB:+itb-}singularity-extras                   /gwms/client_group_main/singularity-extras \
+ && install stashcp/stashcp                                             /gwms/client/stashcp \
+ && install stashcp/stashcp                                             /usr/libexec/condor/stash_plugin \
+ && ln -s   /gwms/client/stashcp                                        /usr/bin/stashcp \
  && echo "OSG_FLOCK_REPO = \"$OSG_FLOCK_REPO\""        >> /etc/condor/config.d/60-flock-sources.config \
  && echo "OSG_FLOCK_BRANCH = \"$OSG_FLOCK_BRANCH\""    >> /etc/condor/config.d/60-flock-sources.config \
  && echo "OSG_FLOCK_HASH = \"$(git rev-parse HEAD)\""  >> /etc/condor/config.d/60-flock-sources.config \
@@ -64,9 +65,6 @@ RUN git clone --branch ${OSG_FLOCK_BRANCH} https://github.com/${OSG_FLOCK_REPO} 
 
 COPY condor_master_wrapper /usr/sbin/
 RUN chmod 755 /usr/sbin/condor_master_wrapper
-
-RUN cp /gwms/client/stashcp /usr/libexec/condor/stash_plugin \
- && chmod 755 /usr/libexec/condor/stash_plugin
 
 # Override the software-base supervisord.conf to throw away supervisord logs
 COPY supervisord.conf /etc/supervisord.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -125,6 +125,8 @@ RUN if [[ -n $TIMESTAMP ]]; then \
 
 RUN \
     if [[ -n $ITB ]]; then \
+        # Set the default pool to ITB, but allow turning off with -e ITBPOOL=0
+        echo 'export ITBPOOL=${ITBPOOL:-1}' > /etc/osg/image-init.d/01-itb.sh; \
         echo 'Is_ITB_Site = True'  >> /etc/condor/config.d/55-itb.config; \
         echo 'STARTD_ATTRS = $(STARTD_ATTRS) Is_ITB_Site'  >> /etc/condor/config.d/55-itb.config; \
         echo 'START = $(START) && (TARGET.ITB_Sites =?= True)'  >> /etc/condor/config.d/55-itb.config; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN mkdir -p /gwms/main /gwms/client /gwms/client_group_main /gwms/.gwms.d/bin /
  && curl -sSfL -o /gwms/main/singularity_setup.sh https://raw.githubusercontent.com/glideinWMS/glideinwms/branch_v3_9/creation/web_base/singularity_setup.sh \
  && curl -sSfL -o /gwms/main/singularity_wrapper.sh https://raw.githubusercontent.com/glideinWMS/glideinwms/branch_v3_9/creation/web_base/singularity_wrapper.sh \
  && curl -sSfL -o /gwms/main/singularity_lib.sh https://raw.githubusercontent.com/glideinWMS/glideinwms/branch_v3_9/creation/web_base/singularity_lib.sh \
- && curl -sSfL -o /gwms/client/stashcp http://stash.osgconnect.net/public/dweitzel/stashcp/current/stashcp \
+ && curl -sSfL -o /gwms/client/stashcp https://github.com/opensciencegrid/osg-flock/raw/master/stashcp/stashcp \
  && chmod 755 /gwms/*.sh /gwms/main/*.sh /gwms/client/stashcp \
  && ln -s /gwms/client/stashcp /usr/bin/stashcp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,15 +46,16 @@ RUN mkdir -p /gwms/main /gwms/client /gwms/client_group_main /gwms/.gwms.d/bin /
 # Set ITB to use itb versions of all the pilot scripts
 ARG ITB=
 # Specify the branch of the opensciencegrid/osg-flock repo to get the pilot scripts from
+ARG FLOCK_REPO=opensciencegrid/osg-flock
 ARG FLOCK_BRANCH=master
-RUN curl -sSfL -o /usr/sbin/osgvo-default-image https://raw.githubusercontent.com/opensciencegrid/osg-flock/${FLOCK_BRANCH}/node-check/${ITB:+itb-}osgvo-default-image \
- && curl -sSfL -o /usr/sbin/osgvo-advertise-base https://raw.githubusercontent.com/opensciencegrid/osg-flock/${FLOCK_BRANCH}/node-check/${ITB:+itb-}osgvo-advertise-base \
- && curl -sSfL -o /usr/sbin/osgvo-advertise-userenv https://raw.githubusercontent.com/opensciencegrid/osg-flock/${FLOCK_BRANCH}/node-check/${ITB:+itb-}osgvo-advertise-userenv \
- && curl -sSfL -o /usr/sbin/osgvo-singularity-wrapper https://raw.githubusercontent.com/opensciencegrid/osg-flock/${FLOCK_BRANCH}/job-wrappers/${ITB:+itb-}default_singularity_wrapper.sh \
- && curl -sSfL -o /gwms/client_group_main/ospool-lib https://raw.githubusercontent.com/opensciencegrid/osg-flock/${FLOCK_BRANCH}/node-check/${ITB:+itb-}ospool-lib \
- && curl -sSfL -o /gwms/client_group_main/singularity-extras https://raw.githubusercontent.com/opensciencegrid/osg-flock/${FLOCK_BRANCH}/node-check/${ITB:+itb-}singularity-extras \
+RUN curl -sSfL -o /usr/sbin/osgvo-default-image https://raw.githubusercontent.com/${FLOCK_REPO}/${FLOCK_BRANCH}/node-check/${ITB:+itb-}osgvo-default-image \
+ && curl -sSfL -o /usr/sbin/osgvo-advertise-base https://raw.githubusercontent.com/${FLOCK_REPO}/${FLOCK_BRANCH}/node-check/${ITB:+itb-}osgvo-advertise-base \
+ && curl -sSfL -o /usr/sbin/osgvo-advertise-userenv https://raw.githubusercontent.com/${FLOCK_REPO}/${FLOCK_BRANCH}/node-check/${ITB:+itb-}osgvo-advertise-userenv \
+ && curl -sSfL -o /usr/sbin/osgvo-singularity-wrapper https://raw.githubusercontent.com/${FLOCK_REPO}/${FLOCK_BRANCH}/job-wrappers/${ITB:+itb-}default_singularity_wrapper.sh \
+ && curl -sSfL -o /gwms/client_group_main/ospool-lib https://raw.githubusercontent.com/${FLOCK_REPO}/${FLOCK_BRANCH}/node-check/${ITB:+itb-}ospool-lib \
+ && curl -sSfL -o /gwms/client_group_main/singularity-extras https://raw.githubusercontent.com/${FLOCK_REPO}/${FLOCK_BRANCH}/node-check/${ITB:+itb-}singularity-extras \
  && chmod 755 /usr/sbin/osgvo-* /gwms/client_group_main/* \
- && echo "OSGVO Glidein scripts are from the ${FLOCK_BRANCH} branch${ITB:+ (ITB)}" >> /IMAGEINFO.txt
+ && echo "OSGVO Glidein scripts are from ${FLOCK_REPO}, ${FLOCK_BRANCH} branch${ITB:+ (ITB)}" >> /IMAGEINFO.txt
 
 COPY condor_master_wrapper /usr/sbin/
 RUN chmod 755 /usr/sbin/condor_master_wrapper

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,13 +40,18 @@ RUN mkdir -p /gwms/main /gwms/client /gwms/client_group_main /gwms/.gwms.d/bin /
  && ln -s /gwms/client/stashcp /usr/bin/stashcp
 
 # osgvo scripts
-RUN curl -sSfL -o /usr/sbin/osgvo-default-image https://raw.githubusercontent.com/opensciencegrid/osg-flock/master/node-check/osgvo-default-image \
- && curl -sSfL -o /usr/sbin/osgvo-advertise-base https://raw.githubusercontent.com/opensciencegrid/osg-flock/master/node-check/osgvo-advertise-base \
- && curl -sSfL -o /usr/sbin/osgvo-advertise-userenv https://raw.githubusercontent.com/opensciencegrid/osg-flock/master/node-check/osgvo-advertise-userenv \
- && curl -sSfL -o /usr/sbin/osgvo-singularity-wrapper https://raw.githubusercontent.com/opensciencegrid/osg-flock/master/job-wrappers/default_singularity_wrapper.sh \
- && curl -sSfL -o /gwms/client_group_main/ospool-lib https://raw.githubusercontent.com/opensciencegrid/osg-flock/master/node-check/ospool-lib \
- && curl -sSfL -o /gwms/client_group_main/singularity-extras https://raw.githubusercontent.com/opensciencegrid/osg-flock/master/node-check/singularity-extras \
- && chmod 755 /usr/sbin/osgvo-* /gwms/client_group_main/*
+# Set ITB to use itb versions of all the pilot scripts
+ARG ITB=
+# Specify the branch of the opensciencegrid/osg-flock repo to get the pilot scripts from
+ARG FLOCK_BRANCH=master
+RUN curl -sSfL -o /usr/sbin/osgvo-default-image https://raw.githubusercontent.com/opensciencegrid/osg-flock/${FLOCK_BRANCH}/node-check/${ITB:+itb-}osgvo-default-image \
+ && curl -sSfL -o /usr/sbin/osgvo-advertise-base https://raw.githubusercontent.com/opensciencegrid/osg-flock/${FLOCK_BRANCH}/node-check/${ITB:+itb-}osgvo-advertise-base \
+ && curl -sSfL -o /usr/sbin/osgvo-advertise-userenv https://raw.githubusercontent.com/opensciencegrid/osg-flock/${FLOCK_BRANCH}/node-check/${ITB:+itb-}osgvo-advertise-userenv \
+ && curl -sSfL -o /usr/sbin/osgvo-singularity-wrapper https://raw.githubusercontent.com/opensciencegrid/osg-flock/${FLOCK_BRANCH}/job-wrappers/${ITB:+itb-}default_singularity_wrapper.sh \
+ && curl -sSfL -o /gwms/client_group_main/ospool-lib https://raw.githubusercontent.com/opensciencegrid/osg-flock/${FLOCK_BRANCH}/node-check/${ITB:+itb-}ospool-lib \
+ && curl -sSfL -o /gwms/client_group_main/singularity-extras https://raw.githubusercontent.com/opensciencegrid/osg-flock/${FLOCK_BRANCH}/node-check/${ITB:+itb-}singularity-extras \
+ && chmod 755 /usr/sbin/osgvo-* /gwms/client_group_main/* \
+ && echo "OSGVO Glidein scripts are from the ${FLOCK_BRANCH} branch${ITB:+ (ITB)}" >> /IMAGEINFO.txt
 
 COPY condor_master_wrapper /usr/sbin/
 RUN chmod 755 /usr/sbin/condor_master_wrapper

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,9 @@ RUN useradd osg \
  && yum clean all \
  && mkdir -p /etc/condor/passwords.d /etc/condor/tokens.d
 
+# Specify RANDOM when building the image to use the cache for installing RPMs but not for downloading scripts.
+ARG RANDOM=
+
 # glideinwms
 RUN mkdir -p /gwms/main /gwms/client /gwms/client_group_main /gwms/.gwms.d/bin /gwms/.gwms.d/exec/{cleanup,postjob,prejob,setup,setup_singularity} \
  && curl -sSfL -o /gwms/error_gen.sh https://raw.githubusercontent.com/glideinWMS/glideinwms/branch_v3_9/creation/web_base/error_gen.sh \


### PR DESCRIPTION
https://opensciencegrid.atlassian.net/browse/SOFTWARE-5002

If you specify `--build-arg ITB=1` when building the container, it will use the itb versions of the osg-flock scripts and also add the attributes for joining the ITB pool.

Other features (intended for manual builds):
- specify your fork of osg-flock in the `OSG_FLOCK_REPO` var, e.g. `--build-arg OSG_FLOCK_REPO=matyasselmeci/osg-flock`
- specify the branch of osg-flock in the `OSG_FLOCK_BRANCH` var, e.g. `--build-arg OSG_FLOCK_BRANCH=mybranch`
- the above two args, as well as `OSG_FLOCK_HASH` (the git hash of the checkout) will be advertised in the startd ad
- specify `--build-arg RANDOM=$RANDOM` to use the docker build cache for the RPM install, but get a fresh checkout of the scripts. This saves a lot of time, especially on slow connections.

The -development-itb tag gets built in the workflow; I don't build -release-itb and -testing-itb because the build matrix is already pretty big.

Includes #60.