### PR TITLE
Install sshd for condor_ssh_to_job; the service doesn't need to be started up, we just need the software

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN useradd osg \
         git \
         rsyslog rsyslog-gnutls python36-cryptography python36-requests \
         bind-utils \
+        openssh-server \
  && yum clean all \
  && mkdir -p /etc/condor/passwords.d /etc/condor/tokens.d
 


### PR DESCRIPTION
(SOFTWARE-4970)
