### PR TITLE
Add prod PATh facility choice to POOL (SOFTWARE-5004)

### DIFF
--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -277,7 +277,9 @@ elif [[ $POOL =~ (itb|prod)-ospool ]]; then
     CCB_SUFFIX="9619?sock=collector$(random_range 1 6)"
 fi
 
-# Append the CCB suffix to each host in CONDOR_HOST
+# Append the CCB suffix to each host in CONDOR_HOST, e.g.
+# "cm.school.edu:10576", or
+# "cm-1.ospool.osg-htc.org:9619?sock=collector6,cm-2.ospool.osg-htc.org:9619?sock=collector6"
 if [[ -n $CCB_RANGE_LOW && -n $CCB_RANGE_HIGH ]] ||
        [[ $POOL =~ (itb|prod)-ospool ]]; then
     CCB_ADDRESS=$(python -Sc "import re; \

--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -268,8 +268,8 @@ fi
 SYSLOG_HOST=${SYSLOG_HOST:-$default_syslog_host}
 
 
-# Don't assume a CCB unless they specify CCB_RANGE_LOW or CCB_RANGE_HIGH
-if [[ -n $CCB_RANGE_LOW ]] || [[ -n $CCB_RANGE_HIGH ]]; then
+# Don't assume a CCB unless they specify CCB_RANGE_LOW and CCB_RANGE_HIGH
+if [[ -n $CCB_RANGE_LOW && -n $CCB_RANGE_HIGH ]]; then
     CCB_PORT=$(python -S -c "import random; print(random.randrange($CCB_RANGE_LOW,$CCB_RANGE_HIGH+1))")
     if [[ $POOL =~ (itb|prod)-ospool ]]; then
         CCB_PORT="9619?sock=collector$CCB_PORT"

--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -267,7 +267,7 @@ fi
 # Configure remote peer if applicable
 SYSLOG_HOST=${SYSLOG_HOST:-$default_syslog_host}
 
-if [[ -n $CCB_RANGE_LOW && $CCB_RANGE_HIGH ]]; then
+if [[ -n $CCB_RANGE_LOW && -n $CCB_RANGE_HIGH ]]; then
     # Choose a random CCB port if the user gives us a port range
     # e.g., cm.school.edu:10576
     CCB_SUFFIX=$(random_range "$CCB_RANGE_LOW" "$CCB_RANGE_HIGH")
@@ -278,7 +278,7 @@ elif [[ $POOL =~ (itb|prod)-ospool ]]; then
 fi
 
 # Append the CCB suffix to each host in CONDOR_HOST
-if [[ -n $CCB_RANGE_LOW && $CCB_RANGE_HIGH ]] ||
+if [[ -n $CCB_RANGE_LOW && -n $CCB_RANGE_HIGH ]] ||
        [[ $POOL =~ (itb|prod)-ospool ]]; then
     CCB_ADDRESS=$(python -Sc "import re; \
 print(','.join([cm + ':$CCB_SUFFIX' \

--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -280,7 +280,9 @@ fi
 # Append the CCB suffix to each host in CONDOR_HOST
 if [[ -n $CCB_RANGE_LOW && $CCB_RANGE_HIGH ]] ||
        [[ $POOL =~ (itb|prod)-ospool ]]; then
-    CCB_ADDRESS=$(python -Sc "import re; print(','.join([cm + ':$CCB_SUFFIX' for cm in re.split(r'[\s,]+', '$CONDOR_HOST')]))")
+    CCB_ADDRESS=$(python -Sc "import re; \
+print(','.join([cm + ':$CCB_SUFFIX' \
+for cm in re.split(r'[\s,]+', '$CONDOR_HOST')]))")
 fi
 
 # https://whogohost.com/host/knowledgebase/308/Valid-Domain-Name-Characters.html rules


### PR DESCRIPTION
Verified that condor started up (I didn't have OSPool tokens handy) when setting `POOL` to nothing, `prod-ospool`, and `itb-ospool` were set. @ddavila0 is working on cm-2 for the PATh facility so that doesn't seem to work quite yet