### PR TITLE
Ensure that the container shuts down correctly after idle/retirement

### DIFF
--- a/10-htcondor.conf
+++ b/10-htcondor.conf
@@ -1,6 +1,6 @@
 [program:condor_master]
 command=/usr/sbin/condor_master_wrapper
-autorestart=True
+autorestart=False
 startsecs=60
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0

--- a/10-htcondor.conf
+++ b/10-htcondor.conf
@@ -1,6 +1,6 @@
 [program:condor_master]
 command=/usr/sbin/condor_master_wrapper
-autorestart=False
+autorestart=unexpected
 startsecs=60
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0

--- a/50-main.config
+++ b/50-main.config
@@ -78,6 +78,9 @@ STARTD_NOCLAIM_SHUTDOWN = $(ACCEPT_IDLE_MINUTES) * 60
 # were sure that START_StartTime was undefined before its first start.)
 MASTER.DAEMON_SHUTDOWN_FAST = ( STARTD_StartTime == 0 ) && ((CurrentTime - DaemonStartTime) > 60)
 
+# callout to a script when the master exits
+DEFAULT_MASTER_SHUTDOWN_SCRIPT = /etc/condor/master_shutdown.sh
+
 # Identify pilot container jobs for gratia-probe detection
 IsOsgVoContainer = True
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,6 +107,7 @@ ENV MEMORY=
 COPY ldconfig_wrapper.sh /usr/local/bin/ldconfig
 COPY 10-ldconfig-cache.sh /etc/osg/image-init.d/
 
+COPY master_shutdown.sh /etc/condor/
 COPY generate-hostcert entrypoint.sh /bin/
 COPY 10-setup-htcondor.sh /etc/osg/image-init.d/
 COPY 10-cleanup-htcondor.sh /etc/osg/image-cleanup.d/

--- a/master_shutdown.sh
+++ b/master_shutdown.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# kill the container when the master shuts down
+kill 1
+


### PR DESCRIPTION
I noticed that the current container did not shut down after exhausting the `ACCEPT_IDLE_MINUTES`/`ACCEPT_JOBS_FOR_HOURS` timeouts. HTCondor would exit, but restart by supervisord. This PR introduces a `DEFAULT_MASTER_SHUTDOWN_SCRIPT` script which runs `kill 1`, similar to the annex HTCondor documentation: https://htcondor.readthedocs.io/en/latest/cloud-computing/annex-customization-guide.html