### PR TITLE
Relax GPU start/rank expressions so that a container will run jobs ev…

### DIFF
--- a/50-main.config
+++ b/50-main.config
@@ -53,14 +53,15 @@ GLIDEIN_ContainerTag = "@CONTAINER_TAG@"
 STARTD_ATTRS = $(STARTD_ATTRS) GLIDEIN_Country GLIDEIN_Site GLIDEIN_ResourceName WorkerGroupName IsOsgVoContainer GLIDEIN_ContainerTag
 
 # only accept new work for a while, for validated nodes and jobs with project name set
-# On GPU nodes, CPU only jobs are only allowed after all GPUs are in use
 START = (isUndefined(DaemonStartTime) || (time() - DaemonStartTime) < (MY.ACCEPT_JOBS_FOR_HOURS*60*60)) && \
         (MY.OSG_NODE_VALIDATED == True) && \
         (!isUndefined(TARGET.ProjectName)) && \
         (isUndefined(MY.RecentJobStarts) || MY.RecentJobStarts < 400) && \
-        ifThenElse(MY.TotalGPUs > 0 && MY.GPUs > 0, TARGET.RequestGPUs > 0, True) && \
         (isUndefined(TARGET.SingularityImage) || MY.SINGULARITY_START_CLAUSE) && \
         ($(START_EXTRA))
+
+# Prefer certain types of jobs, for GPU jobs if they can fit
+RANK = TARGET.RequestGPUs
 
 # Include the osgvo-docker-pilot configuration file, if it exists.
 include ifexist: $ENV(PILOT_CONFIG_FILE)


### PR DESCRIPTION
…en if there are no GPU jobs in the pool, but still prefer GPU jobs if available