### PR TITLE
Added flag ALLOW_CPUJOB_ON_GPUSLOT to give admins control over if the…

### DIFF
--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -132,6 +132,9 @@ fi
 if [ "x$ANNEX_NAME" = "x" ]; then
     export ANNEX_NAME="$GLIDEIN_ResourceName@$GLIDEIN_Site"
 fi
+if [ "x$ALLOW_CPUJOB_ON_GPUSLOT" = "x" ]; then
+    export ALLOW_CPUJOB_ON_GPUSLOT="0"
+fi
 
 LOCAL_DIR=$(mktemp -d /pilot/osgvo-pilot-XXXXXX)
 mkdir -p "$LOCAL_DIR"/condor/tokens.d
@@ -350,6 +353,14 @@ fi
 # ensure HTCondor knows about our squid
 if [ "x$OSG_SQUID_LOCATION" != "x" ]; then
     export http_proxy="$OSG_SQUID_LOCATION"
+fi
+
+# some admins prefer to reserve gpu slots for gpu jobs, others
+# want to run cpu jobs if there are no gpu jobs available
+if [[ $ALLOW_CPUJOB_ON_GPUSLOT = "1" ]]; then
+    echo "CPUJOB_ON_GPUSLOT = True" >> "$PILOT_CONFIG_FILE"
+else
+    echo "CPUJOB_ON_GPUSLOT = ifThenElse(MY.TotalGPUs > 0 && MY.GPUs > 0, TARGET.RequestGPUs > 0, True)" >> "$PILOT_CONFIG_FILE"
 fi
 
 cat >$LOCAL_DIR/user-job-wrapper.sh <<EOF

--- a/50-main.config
+++ b/50-main.config
@@ -58,9 +58,12 @@ START = (isUndefined(DaemonStartTime) || (time() - DaemonStartTime) < (MY.ACCEPT
         (MY.OSG_NODE_VALIDATED == True) && \
         (!isUndefined(TARGET.ProjectName)) && \
         (isUndefined(MY.RecentJobStarts) || MY.RecentJobStarts < 400) && \
-        ifThenElse(MY.TotalGPUs > 0 && MY.GPUs > 0, TARGET.RequestGPUs > 0, True) && \
+        ($(CPUJOB_ON_GPUSLOT)) && \
         (isUndefined(TARGET.SingularityImage) || MY.SINGULARITY_START_CLAUSE) && \
         ($(START_EXTRA))
+
+# Prefer certain types of jobs, for example GPU jobs if they can fit
+RANK = TARGET.RequestGPUs
 
 # Include the osgvo-docker-pilot configuration file, if it exists.
 include ifexist: $ENV(PILOT_CONFIG_FILE)


### PR DESCRIPTION
…y want to make gpu slots available to cpu-only jobs

Note that the default for the flag is to keep the same functionality as we have now.

@dsschult Let me know if this is good by you.