### PR TITLE
add "want_mpi =!= true" to START expression (SOFTWARE-5048)

### DIFF
--- a/50-main.config
+++ b/50-main.config
@@ -63,7 +63,7 @@ START = (isUndefined(DaemonStartTime) || (time() - DaemonStartTime) < (MY.ACCEPT
         (!isUndefined(TARGET.ProjectName)) && \
         ($(CPUJOB_ON_GPUSLOT)) && \
         (isUndefined(TARGET.SingularityImage) || MY.SINGULARITY_START_CLAUSE) && \
-        (want_mpi =!= true) && \
+        (TARGET.Want_MPI =!= True || MY.Has_MPI =?= True) && \
         ($(START_EXTRA))
 
 # Prefer certain types of jobs, for example GPU jobs if they can fit

--- a/50-main.config
+++ b/50-main.config
@@ -63,6 +63,7 @@ START = (isUndefined(DaemonStartTime) || (time() - DaemonStartTime) < (MY.ACCEPT
         (!isUndefined(TARGET.ProjectName)) && \
         ($(CPUJOB_ON_GPUSLOT)) && \
         (isUndefined(TARGET.SingularityImage) || MY.SINGULARITY_START_CLAUSE) && \
+        (want_mpi =!= true) && \
         ($(START_EXTRA))
 
 # Prefer certain types of jobs, for example GPU jobs if they can fit


### PR DESCRIPTION
SOFTWARE-5048 originally called for adding just `want_mpi =!= true` to the `START` expression.

In the comments, @matyasselmeci then suggested `(TARGET.Want_MPI =!= True || MY.Has_MPI =?= True)` might be better, so I've added that instead.