### PR TITLE
Unset SINGULARITY_BIND so that singularity-in-singularity doesn't attempt to propagate bind mounts from outside (SOFTWARE-5207)

### DIFF
--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -453,6 +453,7 @@ else
 fi
 rm -f /tmp/stashcp-debug.txt
 
+unset SINGULARITY_BIND
 export GLIDEIN_SINGULARITY_BINARY_OVERRIDE=/usr/bin/singularity
 /usr/sbin/osgvo-default-image $glidein_config
 ./main/singularity_setup.sh $glidein_config


### PR DESCRIPTION
(which leads to 'mount source ... does not exist' errors, see https://github.com/apptainer/singularity/issues/5766)