### PR TITLE
kill supervisord with SIGQUIT (SOFTWARE-4608)

### DIFF
--- a/master_shutdown.sh
+++ b/master_shutdown.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 # kill the container when the master shuts down
-kill 1
+kill -QUIT 1
 

--- a/master_shutdown.sh
+++ b/master_shutdown.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 # kill the container when the master shuts down
-kill -QUIT 1
+supervisorctl shutdown
 


### PR DESCRIPTION
kill defaults to SIGTERM, but I found some pages [1,2] with examples killing supervisord specifically using SIGQUIT.  Could this be the key to what went wrong?

Then again, the supervisord docs suggest[1] that a number of signals including TERM will cause it to shut down, so I am not wildly confident this will actually fix it.

[1] https://serverfault.com/questions/760726/how-to-exit-all-supervisor-processes-if-one-exited-with-0-result
[2] https://hangarau.space/using-supervisord-as-the-init-process-of-a-docker-container/
[3] http://supervisord.org/running.html#signal-handlers