### PR TITLE
SOFTWARE-5317 Update OSG container actions to automatically generate the TIMESTAMP_TAG build variable

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -9,15 +9,6 @@ on:
   workflow_dispatch:
 
 jobs:
-#   make-date-tag:
-#     runs-on: ubuntu-latest
-#     outputs:
-#       dtag: ${{ steps.mkdatetag.outputs.dtag }}
-#     steps:
-#     - name: make date tag
-#       id: mkdatetag
-#       run: echo "::set-output name=dtag::$(date +%Y%m%d-%H%M)"
-
   build:
     runs-on: ubuntu-latest
     needs: []
@@ -31,8 +22,6 @@ jobs:
         with:
           osg_series: ${{ matrix.osg_series }}
           repo: ${{ matrix.repo }}
-#           timestamp_tag: ${{ needs.make-date-tag.outputs.dtag }}
-
   test:
     runs-on: ubuntu-20.04
     needs: [build]

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -9,18 +9,18 @@ on:
   workflow_dispatch:
 
 jobs:
-  make-date-tag:
-    runs-on: ubuntu-latest
-    outputs:
-      dtag: ${{ steps.mkdatetag.outputs.dtag }}
-    steps:
-    - name: make date tag
-      id: mkdatetag
-      run: echo "::set-output name=dtag::$(date +%Y%m%d-%H%M)"
+#   make-date-tag:
+#     runs-on: ubuntu-latest
+#     outputs:
+#       dtag: ${{ steps.mkdatetag.outputs.dtag }}
+#     steps:
+#     - name: make date tag
+#       id: mkdatetag
+#       run: echo "::set-output name=dtag::$(date +%Y%m%d-%H%M)"
 
   build:
     runs-on: ubuntu-latest
-    needs: [make-date-tag]
+    needs: []
     strategy:
       fail-fast: false
       matrix:
@@ -31,11 +31,11 @@ jobs:
         with:
           osg_series: ${{ matrix.osg_series }}
           repo: ${{ matrix.repo }}
-          timestamp_tag: ${{ needs.make-date-tag.outputs.dtag }}
+#           timestamp_tag: ${{ needs.make-date-tag.outputs.dtag }}
 
   test:
     runs-on: ubuntu-20.04
-    needs: [make-date-tag, build]
+    needs: [build]
     strategy:
       fail-fast: false
       matrix:
@@ -52,7 +52,7 @@ jobs:
         with:
           osg_series: ${{ matrix.osg_series }}
           repo: ${{ matrix.repo }}
-          timestamp_tag: ${{ needs.make-date-tag.outputs.dtag }}
+          timestamp_tag: ${{ needs.build.outputs.tags }}
       - name: Run tests
         env:
           CONTAINER_RUNTIME: ${{ matrix.runtime }}
@@ -64,7 +64,7 @@ jobs:
                                           "$CONTAINER_IMAGE"
   push:
     runs-on: ubuntu-latest
-    needs: [make-date-tag, build, test]
+    needs: [build, test]
     if: >-
       github.ref == 'refs/heads/master' &&
       github.event_name != 'pull_request' &&
@@ -85,7 +85,7 @@ jobs:
         with:
           osg_series: ${{ matrix.osg_series }}
           repo: ${{ matrix.repo }}
-          timestamp_tag: ${{ needs.make-date-tag.outputs.dtag }}
+          timestamp_tag: ${{ needs.build.outputs.tags }}
           registry_url: ${{ matrix.registry.url }}
           registry_user: ${{ secrets[matrix.registry.username] }}
           registry_pass: ${{ secrets[matrix.registry.password] }}


### PR DESCRIPTION
Updates to action versions may be necessary (EX: lowercasing for load-action is not right version right now)