### PR TITLE
Install ITB scripts and allow selecting between production and ITB

### DIFF
--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -162,6 +162,7 @@ case ${POOL} in
         default_ccb2=ccb-2.ospool-itb.osg-htc.org
         default_syslog_host=syslog.osgdev.chtc.io
         GLIDECLIENT_Group=itb-container
+        itb_sites_start_clause=' && (TARGET.ITB_Sites =?= True)'
         ;;
     prod-ospool)
         default_cm1=cm-1.ospool.osg-htc.org
@@ -170,12 +171,14 @@ case ${POOL} in
         default_ccb2=ccb-2.ospool.osg-htc.org
         default_syslog_host=syslog.osg.chtc.io
         GLIDECLIENT_Group=main-container
+        itb_sites_start_clause=' && (TARGET.ITB_Sites =!= True)'
         ;;
     prod-path-facility)
         default_cm1=cm-1.facility.path-cc.io
         default_cm2=cm-2.facility.path-cc.io
         default_syslog_host=syslog.osg.chtc.io
         GLIDECLIENT_Group=path-container
+        itb_sites_start_clause=''
         ;;
     *)
         echo "Unknown pool $POOL" >&2
@@ -375,7 +378,7 @@ SHARED_PORT_PORT = 0
 NETWORK_HOSTNAME = $NETWORK_HOSTNAME
 
 # additional start expression requirements - this will be &&ed to the base one
-START_EXTRA = $GLIDEIN_Start_Extra
+START_EXTRA = $GLIDEIN_Start_Extra $itb_sites_start_clause
 
 GLIDEIN_Site = "$GLIDEIN_Site"
 GLIDEIN_ResourceName = "$GLIDEIN_ResourceName"

--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -154,6 +154,7 @@ else
 fi
 
 
+itb_sites_start_clause=''
 case ${POOL} in
     itb-ospool)
         default_cm1=cm-1.ospool-itb.osg-htc.org
@@ -178,7 +179,6 @@ case ${POOL} in
         default_cm2=cm-2.facility.path-cc.io
         default_syslog_host=syslog.osg.chtc.io
         GLIDECLIENT_Group=path-container
-        itb_sites_start_clause=''
         ;;
     *)
         echo "Unknown pool $POOL" >&2

--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -139,18 +139,18 @@ fi
 #
 
 # Default to the production OSPool unless $ITB is set
-if ! is_true "$ITB"; then
-    POOL=${POOL:=prod-ospool}
-    glidein_group=main
-    glidein_group_dir=client_group_main
-    script_exec_prefix=/usr/sbin/
-    script_lib_prefix=/gwms/client_group_main/
-else
+if is_true "$ITB"; then
     POOL=${POOL:=itb-ospool}
     glidein_group=itb
     glidein_group_dir=client_group_itb
     script_exec_prefix=/usr/sbin/itb-
     script_lib_prefix=/gwms/client_group_itb/itb-
+else
+    POOL=${POOL:=prod-ospool}
+    glidein_group=main
+    glidein_group_dir=client_group_main
+    script_exec_prefix=/usr/sbin/
+    script_lib_prefix=/gwms/client_group_main/
 fi
 
 

--- a/50-main.config
+++ b/50-main.config
@@ -43,7 +43,8 @@ GLIDEIN_ContainerTag = "@CONTAINER_TAG@"
 
 STARTD_ATTRS = $(STARTD_ATTRS) GLIDEIN_Country GLIDEIN_Site GLIDEIN_ResourceName \
                WorkerGroupName IsOsgVoContainer GLIDEIN_ContainerTag \
-               IsBlackHole HasExcessiveLoad GLIDECLIENT_Group
+               IsBlackHole HasExcessiveLoad GLIDECLIENT_Group \
+               Is_ITB_Site
 
 IsBlackHole = IfThenElse(RecentJobDurationAvg is undefined, false, RecentJobDurationCount >= 10 && RecentJobDurationAvg < 180)
 HasExcessiveLoad = LoadAvg > 2*DetectedCpus + 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,11 +76,11 @@ RUN git clone --branch ${OSG_FLOCK_BRANCH} https://github.com/${OSG_FLOCK_REPO} 
  && install node-check/ospool-lib                                       /gwms/client_group_main/ospool-lib \
  && install node-check/singularity-extras                               /gwms/client_group_main/singularity-extras \
  # itb files: \
- && install node-check/itb-osgvo-default-image                          /usr/sbin/itb-osgvo-default-image \
- && install node-check/itb-osgvo-advertise-base                         /usr/sbin/itb-osgvo-advertise-base \
- && install node-check/itb-osgvo-advertise-userenv                      /usr/sbin/itb-osgvo-advertise-userenv \
- && install node-check/itb-ospool-lib                                   /gwms/client_group_itb/itb-ospool-lib \
- && install node-check/itb-singularity-extras                           /gwms/client_group_itb/itb-singularity-extras \
+ && install ospool-pilot/itb/pilot/default-image                        /usr/sbin/itb-osgvo-default-image \
+ && install ospool-pilot/itb/pilot/advertise-base                       /usr/sbin/itb-osgvo-advertise-base \
+ && install ospool-pilot/itb/pilot/advertise-userenv                    /usr/sbin/itb-osgvo-advertise-userenv \
+ && install ospool-pilot/itb/lib/ospool-lib                             /gwms/client_group_itb/itb-ospool-lib \
+ && install ospool-pilot/itb/pilot/singularity-extras                   /gwms/client_group_itb/itb-singularity-extras \
  && install job-wrappers/itb-default_singularity_wrapper.sh             /usr/sbin/itb-osgvo-singularity-wrapper \
  # common files: \
  && install stashcp/stashcp                                             /gwms/client/stashcp \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ FROM opensciencegrid/software-base:${BASE_OSG_SERIES}-el8-${BASE_YUM_REPO}
 
 ENV IS_CONTAINER_PILOT=1
 
+# Set this to "1" to use ITB versions of scripts and connect to the ITB pool
+ENV ITB=
+
 # Previous args have gone out of scope
 ARG BASE_OSG_SERIES=3.6
 ARG BASE_YUM_REPO=testing
@@ -43,7 +46,7 @@ ARG RANDOM=
 # glideinwms
 ARG GWMS_REPO=edquist/glideinwms
 ARG GWMS_BRANCH=SOFTWARE-5340.fix-PATH
-RUN mkdir -p /gwms/main /gwms/client /gwms/client_group_main /gwms/.gwms.d/bin /gwms/.gwms.d/exec/{cleanup,postjob,prejob,setup,setup_singularity} \
+RUN mkdir -p /gwms/main /gwms/client /gwms/client_group_main /gwms/client_group_itb /gwms/.gwms.d/bin /gwms/.gwms.d/exec/{cleanup,postjob,prejob,setup,setup_singularity} \
  && git clone --depth=1 --branch ${GWMS_BRANCH} https://github.com/${GWMS_REPO} glideinwms \
  && cd glideinwms \
  && install creation/web_base/error_gen.sh            /gwms/error_gen.sh                        \
@@ -65,19 +68,30 @@ ARG OSG_FLOCK_REPO=opensciencegrid/osg-flock
 ARG OSG_FLOCK_BRANCH=master
 RUN git clone --branch ${OSG_FLOCK_BRANCH} https://github.com/${OSG_FLOCK_REPO} osg-flock \
  && cd osg-flock \
+ # production files: \
  && install node-check/osgvo-default-image                              /usr/sbin/osgvo-default-image \
  && install node-check/osgvo-advertise-base                             /usr/sbin/osgvo-advertise-base \
  && install node-check/osgvo-advertise-userenv                          /usr/sbin/osgvo-advertise-userenv \
  && install job-wrappers/default_singularity_wrapper.sh                 /usr/sbin/osgvo-singularity-wrapper \
  && install node-check/ospool-lib                                       /gwms/client_group_main/ospool-lib \
  && install node-check/singularity-extras                               /gwms/client_group_main/singularity-extras \
+ # itb files: \
+ && install node-check/itb-osgvo-default-image                          /usr/sbin/itb-osgvo-default-image \
+ && install node-check/itb-osgvo-advertise-base                         /usr/sbin/itb-osgvo-advertise-base \
+ && install node-check/itb-osgvo-advertise-userenv                      /usr/sbin/itb-osgvo-advertise-userenv \
+ && install node-check/itb-ospool-lib                                   /gwms/client_group_itb/itb-ospool-lib \
+ && install node-check/itb-singularity-extras                           /gwms/client_group_itb/itb-singularity-extras \
+ && install job-wrappers/itb-default_singularity_wrapper.sh             /usr/sbin/itb-osgvo-singularity-wrapper \
+ # common files: \
  && install stashcp/stashcp                                             /gwms/client/stashcp \
  && install stashcp/stash_plugin                                        /usr/libexec/condor/stash_plugin \
  && ln -snf /gwms/client/stashcp                                        /usr/bin/stashcp \
+ # advertise info \
  && echo "OSG_FLOCK_REPO = \"$OSG_FLOCK_REPO\""        >> /etc/condor/config.d/60-flock-sources.config \
  && echo "OSG_FLOCK_BRANCH = \"$OSG_FLOCK_BRANCH\""    >> /etc/condor/config.d/60-flock-sources.config \
  && echo "OSG_FLOCK_HASH = \"$(git rev-parse HEAD)\""  >> /etc/condor/config.d/60-flock-sources.config \
  && echo "STARTD_ATTRS = \$(STARTD_ATTRS) OSG_FLOCK_REPO OSG_FLOCK_BRANCH OSG_FLOCK_HASH"  >> /etc/condor/config.d/60-flock-sources.config \
+ # cleanup \
  && cd .. && rm -rf osg-flock
 
 COPY condor_master_wrapper /usr/sbin/


### PR DESCRIPTION
This installs both the ITB and production scripts into separate directories. When the container is started with `-e ITB=1`, the ITB scripts will be used and the pilot will advertise itself as an ITB site and join the ITB pool.

This does not yet use `additional-htcondor-config` or the `prepare-job` hook, and it uses the old singularity wrapper for ITB as well, so right now the two kinds of pilots are very similar.  Those fixups will be coming in a later PR.