### PR TITLE
Fix set_var() to not use the variable name as the value if the variable has an empty value

### DIFF
--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -27,7 +27,8 @@ set_var() {
         return 0
     fi
 
-    var_val=`grep "^$var_name " $glidein_config | awk '{if (NF>1) ind=length($1)+1; v=substr($0, ind); print substr(v, index(v, $2))}'`
+    var_name_len=${#var_name}
+    var_val=$(grep "^${var_name} " $glidein_config | tail -n 1 | cut -c $((var_name_len + 2))- )
     if [ -z "$var_val" ]; then
         if [ "$var_req" == "Y" ]; then
             # needed var, exit with error


### PR DESCRIPTION
If a variable in the glidein config looked like `OSG_SITE_NAME ` (i.e. with a trailing space but no value), then the awk expression in set_var() would use `OSG_SITE_NAME ` as the value instead of the empty string.

This was fixed in GlideinWMS somewhere between 3.9.6rc4 and 3.9.6 so we should use their version once we can (so after #103 is fixed and merged).