### PR TITLE
Install "apptainer" instead of "singularity"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN useradd osg \
  && yum -y install \
         osg-wn-client \
         redhat-lsb-core \
-        singularity \
+        apptainer \
         attr \
         git \
         rsyslog rsyslog-gnutls python3-cryptography python3-requests \


### PR DESCRIPTION
The RPM named "singularity" has been removed from EPEL and the "provides: singularity" line has been removed from apptainer, so now we need to ask for it by name.