### PR TITLE
Fix advertised container tag for new build action

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -32,7 +32,7 @@ jobs:
           fi
 
       - id: build-image
-        uses: opensciencegrid/build-container-action@v0.5.0
+        uses: opensciencegrid/build-container-action@v0.6.0
         with:
           osg_series: ${{ matrix.osg_series }}
           osg_repo: ${{ matrix.repo }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,7 @@ ENV ITB=
 # Previous args have gone out of scope
 ARG BASE_OSG_SERIES=3.6
 ARG BASE_YUM_REPO=testing
-ARG TIMESTAMP_TAG
-
-ARG CONTAINER_TAG=${TIMESTAMP_TAG}
+ARG TIMESTAMP_IMAGE=osgvo-docker-pilot:${BASE_OSG_SERIES}-${BASE_YUM_REPO}
 
 RUN useradd osg \
  && mkdir -p ~osg/.condor \
@@ -153,7 +151,7 @@ COPY 10-htcondor.conf 10-rsyslogd.conf /etc/supervisord.d/
 COPY 50-main.config /etc/condor/config.d/
 COPY rsyslog.conf /etc/
 RUN chmod 755 /bin/entrypoint.sh
-RUN sed -i "s|@CONTAINER_TAG@|${CONTAINER_TAG}|" /etc/condor/config.d/50-main.config
+RUN sed -i "s|@CONTAINER_TAG@|${TIMESTAMP_IMAGE}|" /etc/condor/config.d/50-main.config
 
 
 RUN chown -R osg: ~osg 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV ITB=
 ARG BASE_OSG_SERIES=3.6
 ARG BASE_OS=el8
 ARG BASE_YUM_REPO=testing
-ARG TIMESTAMP_IMAGE=osgvo-docker-pilot:${BASE_OSG_SERIES}-${BASE_OS}-${BASE_YUM_REPO}
+ARG TIMESTAMP_IMAGE=osgvo-docker-pilot:${BASE_OSG_SERIES}-${BASE_OS}-${BASE_YUM_REPO}-$(date +%Y%m%d-%H%M)
 
 RUN useradd osg \
  && mkdir -p ~osg/.condor \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ARG BASE_OSG_SERIES=3.6
 ARG BASE_YUM_REPO=testing
 ARG TIMESTAMP_TAG
 
-ARG CONTAINER_TAG=opensciencegrid/osgvo-docker-pilot:${BASE_OSG_SERIES}-${BASE_YUM_REPO}-${TIMESTAMP_TAG}
+ARG CONTAINER_TAG=${TIMESTAMP_TAG}
 
 RUN useradd osg \
  && mkdir -p ~osg/.condor \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,9 @@ ENV ITB=
 
 # Previous args have gone out of scope
 ARG BASE_OSG_SERIES=3.6
+ARG BASE_OS=el8
 ARG BASE_YUM_REPO=testing
-ARG TIMESTAMP_IMAGE=osgvo-docker-pilot:${BASE_OSG_SERIES}-${BASE_YUM_REPO}
+ARG TIMESTAMP_IMAGE=osgvo-docker-pilot:${BASE_OSG_SERIES}-${BASE_OS}-${BASE_YUM_REPO}
 
 RUN useradd osg \
  && mkdir -p ~osg/.condor \


### PR DESCRIPTION
Otherwise we get junk like this:

`opensciencegrid/osgvo-docker-pilot:3.6-release-opensciencegrid/osgvo-docker-pilot:3.6-cuda_11_8_0-release-20230109-2007`