### PR TITLE
Add ENABLE_REMOTE_SYSLOG (default on)

### DIFF
--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -243,12 +243,18 @@ else
     REGISTRY_HOSTNAME="os-registry.opensciencegrid.org"
 fi
 
-if ! nslookup "$SYSLOG_HOST" >/dev/null; then
-    echo >&2 "*** SYSLOG_HOST $SYSLOG_HOST not found"
-    SYSLOG_HOST=""
+if ! is_true $ENABLE_REMOTE_SYSLOG; then
+    SYSLOG_HOST=
+    REGISTRY_HOSTNAME=
+    REGISTRY_HOST=
 else
-    # If hostcert generation fails, then we'll just skip the whole syslog thing.
-    generate-hostcert "$_CONDOR_SEC_PASSWORD_FILE" "$REGISTRY_HOSTNAME" || SYSLOG_HOST=""
+    if ! nslookup "$SYSLOG_HOST" >/dev/null; then
+        echo >&2 "*** SYSLOG_HOST $SYSLOG_HOST not found"
+        SYSLOG_HOST=""
+    else
+        # If hostcert generation fails, then we'll just skip the whole syslog thing.
+        generate-hostcert "$_CONDOR_SEC_PASSWORD_FILE" "$REGISTRY_HOSTNAME" || SYSLOG_HOST=""
+    fi
 fi
 
 if [[ "x$SYSLOG_HOST" != "x" ]]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ ENV IS_CONTAINER_PILOT=1
 # Set this to "1" to use ITB versions of scripts and connect to the ITB pool
 ENV ITB=
 
+# Set this to empty to not send syslog remotely
+ENV ENABLE_REMOTE_SYSLOG=1
+
 # Previous args have gone out of scope
 ARG BASE_OSG_SERIES=3.6
 ARG BASE_OS=el8


### PR DESCRIPTION
Add a knob to enable/disable remote syslog (it defaults to enabled). Without this there's no clean way to disable it, since setting SYSLOG_HOST to blank just makes it use the default syslog host.