### PR TITLE
Ask for apptainer by name (SOFTWARE-5401)

### DIFF
--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -500,7 +500,7 @@ GLIDEIN_Singularity_Use PREFERRED
 OSG_DEFAULT_CONTAINER_DISTRIBUTION $OSG_DEFAULT_CONTAINER_DISTRIBUTION
 SINGULARITY_IMAGE_RESTRICTIONS None
 SINGULARITY_DISABLE_PID_NAMESPACES $SINGULARITY_DISABLE_PID_NAMESPACES
-GWMS_SINGULARITY_PATH /usr/bin/singularity
+GWMS_SINGULARITY_PATH /usr/bin/apptainer
 GLIDEIN_WORK_DIR $PWD/main
 GLIDECLIENT_WORK_DIR $PWD/client
 GLIDECLIENT_GROUP_WORK_DIR $PWD/$glidein_group_dir
@@ -519,7 +519,7 @@ fi
 rm -f /tmp/stashcp-debug.txt
 
 unset SINGULARITY_BIND
-export GLIDEIN_SINGULARITY_BINARY_OVERRIDE=/usr/bin/singularity
+export GLIDEIN_SINGULARITY_BINARY_OVERRIDE=/usr/bin/apptainer
 ${default_image_executable} $glidein_config
 ./main/singularity_setup.sh $glidein_config
 ${singularity_extras_lib}   $glidein_config

--- a/tests/test_inside_gha.sh
+++ b/tests/test_inside_gha.sh
@@ -20,15 +20,15 @@ SINGULARITY_OUTPUT=$(mktemp)
 PILOT_DIR=$(mktemp -d)
 function start_singularity_backfill {
     useradd -mG docker testuser
-    singularity=/cvmfs/oasis.opensciencegrid.org/mis/singularity/bin/singularity
+    singularity=/cvmfs/oasis.opensciencegrid.org/mis/apptainer/bin/apptainer
     echo -n "Singularity version is: "
     $singularity version
     chown testuser: $SINGULARITY_OUTPUT $PILOT_DIR
     su - testuser -c \
-       "SINGULARITYENV_TOKEN=None \
-       SINGULARITYENV_GLIDEIN_Site=None \
-       SINGULARITYENV_GLIDEIN_ResourceName=None \
-       SINGULARITYENV_GLIDEIN_Start_Extra=True \
+       "APPTAINERENV_TOKEN=None \
+       APPTAINERENV_GLIDEIN_Site=None \
+       APPTAINERENV_GLIDEIN_ResourceName=None \
+       APPTAINERENV_GLIDEIN_Start_Extra=True \
        $singularity \
           run \
             -B /cvmfs \


### PR DESCRIPTION
We are already using apptainer for running singularity containers, but we're calling it through the /usr/bin/singularity symlink. Use the binary directly.