### PR TITLE
Add GLIDEIN_RANDOMIZE_NAME knob to add a random string to the NETWORK_HOSTNAME

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ ENV ITB=
 # Set this to empty to not send syslog remotely
 ENV ENABLE_REMOTE_SYSLOG=1
 
+# Set this to 1 to add a random string in the NETWORK_HOSTNAME (useful if running multiple containers with the same actual hostname)
+ENV GLIDEIN_RANDOMIZE_NAME=
+
 # Previous args have gone out of scope
 ARG BASE_OSG_SERIES=3.6
 ARG BASE_OS=al8


### PR DESCRIPTION
[SOFTWARE-5222](https://opensciencegrid.atlassian.net/browse/SOFTWARE-5222)

Add a 10-char random string to the NETWORK_HOSTNAME so it's unique on places using host networking.

Also turns out I had the rules for domain names wrong -- instead of a 63-char length limit overall, it's a 63-char length limit _per dot-separated-component_ and a 255-char length limit overall. This makes generating names a bit simpler.


[SOFTWARE-5222]: https://opensciencegrid.atlassian.net/browse/SOFTWARE-5222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ