### PR TITLE
Allow use of the prepare-job-hook for ITB container pilots

### DIFF
--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -519,6 +519,7 @@ else
 fi
 rm -f /tmp/stashcp-debug.txt
 
+export IS_CONTAINER_PILOT=1
 if [[ -e ${osgvo_additional_htcondor_config} ]]; then
     echo >&2 "${osgvo_additional_htcondor_config} found; running it"
     bash -x ${osgvo_additional_htcondor_config} $glidein_config

--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -538,7 +538,7 @@ $PWD/main/singularity_wrapper.sh ./"$(basename ${osgvo_advertise_userenv})" glid
 
 if [[ -e ${osgvo_additional_htcondor_config} ]]; then
     echo >&2 "${osgvo_additional_htcondor_config} found; running it"
-    bash -x ${osgvo_additional_htcondor_config} $glidein_config
+    bash ${osgvo_additional_htcondor_config} $glidein_config
     echo >&2 "${osgvo_additional_htcondor_config} done"
 else
     echo >&2 "${osgvo_additional_htcondor_config} not found"

--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -516,13 +516,6 @@ fi
 rm -f /tmp/stashcp-debug.txt
 
 export IS_CONTAINER_PILOT=1
-if [[ -e ${osgvo_additional_htcondor_config} ]]; then
-    echo >&2 "${osgvo_additional_htcondor_config} found; running it"
-    bash -x ${osgvo_additional_htcondor_config} $glidein_config
-    echo >&2 "${osgvo_additional_htcondor_config} done"
-else
-    echo >&2 "${osgvo_additional_htcondor_config} not found"
-fi
 
 unset SINGULARITY_BIND
 export GLIDEIN_SINGULARITY_BINARY_OVERRIDE=/usr/bin/apptainer
@@ -533,6 +526,14 @@ ${singularity_extras_lib}   $glidein_config
 # run the osgvo userenv advertise script
 cp ${osgvo_advertise_userenv} .
 $PWD/main/singularity_wrapper.sh ./$(basename ${osgvo_advertise_userenv}) glidein_config osgvo-docker-pilot
+
+if [[ -e ${osgvo_additional_htcondor_config} ]]; then
+    echo >&2 "${osgvo_additional_htcondor_config} found; running it"
+    bash -x ${osgvo_additional_htcondor_config} $glidein_config
+    echo >&2 "${osgvo_additional_htcondor_config} done"
+else
+    echo >&2 "${osgvo_additional_htcondor_config} not found"
+fi
 
 # last step - interpret the condor_vars
 set +x

--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -355,6 +355,7 @@ NETWORK_HOSTNAME="${sanitized_resourcename}-$(hostname)"
 
 osgvo_advertise_base=${script_exec_prefix}osgvo-advertise-base
 osgvo_advertise_userenv=${script_exec_prefix}osgvo-advertise-userenv
+osgvo_additional_htcondor_config=${script_exec_prefix}osgvo-additional-htcondor-config
 osgvo_singularity_wrapper=${script_exec_prefix}osgvo-singularity-wrapper
 default_image_executable=${script_exec_prefix}osgvo-default-image
 singularity_extras_lib=${script_lib_prefix}singularity-extras
@@ -517,6 +518,14 @@ else
     echo >&2 "stash_plugin test failed; 'stash' filetransfer plugin unavailable"
 fi
 rm -f /tmp/stashcp-debug.txt
+
+if [[ -e ${osgvo_additional_htcondor_config} ]]; then
+    echo >&2 "${osgvo_additional_htcondor_config} found; running it"
+    bash -x ${osgvo_additional_htcondor_config} $glidein_config
+    echo >&2 "${osgvo_additional_htcondor_config} done"
+else
+    echo >&2 "${osgvo_additional_htcondor_config} not found"
+fi
 
 unset SINGULARITY_BIND
 export GLIDEIN_SINGULARITY_BINARY_OVERRIDE=/usr/bin/apptainer

--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -417,11 +417,7 @@ STARTD_CRON_userenv_RECONFIG = true
 STARTD_CRON_userenv_KILL = true
 STARTD_CRON_userenv_ARGS = ${osgvo_advertise_userenv} $LOCAL_DIR/glidein_config main
 
-# Manage disk usage for backfill containers:
-
-DISK_EXCEEDED = (JobUniverse != 13 && DiskUsage =!= UNDEFINED && DiskUsage > Disk)
-HOLD_REASON_DISK_EXCEEDED = disk usage exceeded request_disk
-use POLICY : WANT_HOLD_IF( DISK_EXCEEDED, \$(HOLD_SUBCODE_DISK_EXCEEDED:104), \$(HOLD_REASON_DISK_EXCEEDED) )
+# WANT_HOLD for exceeding disk is set up in 'additional-htcondor-config'
 
 EOF
 

--- a/50-main.config
+++ b/50-main.config
@@ -43,10 +43,10 @@ GLIDEIN_ContainerTag = "@CONTAINER_TAG@"
 
 STARTD_ATTRS = $(STARTD_ATTRS) GLIDEIN_Country GLIDEIN_Site GLIDEIN_ResourceName \
                WorkerGroupName IsOsgVoContainer GLIDEIN_ContainerTag \
-               IsBlackHole HasExcessiveLoad GLIDECLIENT_Group \
+               HasExcessiveLoad GLIDECLIENT_Group \
                Is_ITB_Site
 
-IsBlackHole = IfThenElse(RecentJobDurationAvg is undefined, false, RecentJobDurationCount >= 10 && RecentJobDurationAvg < 180)
+# IsBlackHole is set in "additional-htcondor-config"
 HasExcessiveLoad = LoadAvg > 2*DetectedCpus + 2
 
 # only accept new work for a while, for validated nodes and jobs with project name set

--- a/50-main.config
+++ b/50-main.config
@@ -43,11 +43,11 @@ GLIDEIN_ContainerTag = "@CONTAINER_TAG@"
 
 STARTD_ATTRS = $(STARTD_ATTRS) GLIDEIN_Country GLIDEIN_Site GLIDEIN_ResourceName \
                WorkerGroupName IsOsgVoContainer GLIDEIN_ContainerTag \
-               HasExcessiveLoad GLIDECLIENT_Group \
+               GLIDECLIENT_Group \
                Is_ITB_Site
 
 # IsBlackHole is set in "additional-htcondor-config"
-HasExcessiveLoad = LoadAvg > 2*DetectedCpus + 2
+# HasExcessiveLoad is set in "additional-htcondor-config"
 
 # only accept new work for a while, for validated nodes and jobs with project name set
 # On GPU nodes, CPU only jobs are only allowed after all GPUs are in use

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,8 +99,8 @@ RUN mkdir -p /gwms/main /gwms/client /gwms/client_group_main /gwms/client_group_
 
 # osgvo scripts
 # Specify the branch and fork of the opensciencegrid/osg-flock repo to get the pilot scripts from
-ARG OSG_FLOCK_REPO=opensciencegrid/osg-flock
-ARG OSG_FLOCK_BRANCH=master
+ARG OSG_FLOCK_REPO=matyasselmeci/osg-flock
+ARG OSG_FLOCK_BRANCH=pr/SOFTWARE-5363.container-additional-htcondor-config
 RUN git clone --branch ${OSG_FLOCK_BRANCH} https://github.com/${OSG_FLOCK_REPO} osg-flock \
  && cd osg-flock \
  # production files: \
@@ -114,6 +114,7 @@ RUN git clone --branch ${OSG_FLOCK_BRANCH} https://github.com/${OSG_FLOCK_REPO} 
  && install ospool-pilot/itb/pilot/default-image                        /usr/sbin/itb-osgvo-default-image \
  && install ospool-pilot/itb/pilot/advertise-base                       /usr/sbin/itb-osgvo-advertise-base \
  && install ospool-pilot/itb/pilot/advertise-userenv                    /usr/sbin/itb-osgvo-advertise-userenv \
+ && install ospool-pilot/itb/pilot/additional-htcondor-config           /usr/sbin/itb-osgvo-additional-htcondor-config \
  && install ospool-pilot/itb/lib/ospool-lib                             /gwms/client_group_itb/itb-ospool-lib \
  && install ospool-pilot/itb/pilot/singularity-extras                   /gwms/client_group_itb/itb-singularity-extras \
  && install job-wrappers/itb-default_singularity_wrapper.sh             /usr/sbin/itb-osgvo-singularity-wrapper \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,6 @@ RUN apk --no-cache add gcc musl-dev && \
 
 FROM opensciencegrid/software-base:${BASE_OSG_SERIES}-${BASE_OS}-${BASE_YUM_REPO}
 
-ENV IS_CONTAINER_PILOT=1
-
 # Set this to "1" to use ITB versions of scripts and connect to the ITB pool
 ENV ITB=
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -106,8 +106,8 @@ RUN mkdir -p /gwms/main /gwms/client /gwms/client_group_main /gwms/client_group_
 
 # osgvo scripts
 # Specify the branch and fork of the opensciencegrid/osg-flock repo to get the pilot scripts from
-ARG OSG_FLOCK_REPO=matyasselmeci/osg-flock
-ARG OSG_FLOCK_BRANCH=pr/SOFTWARE-5363.container-additional-htcondor-config
+ARG OSG_FLOCK_REPO=opensciencegrid/osg-flock
+ARG OSG_FLOCK_BRANCH=master
 RUN git clone --branch ${OSG_FLOCK_BRANCH} https://github.com/${OSG_FLOCK_REPO} osg-flock \
  && cd osg-flock \
  # production files: \

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,10 @@ RUN if [[ $BASE_YUM_REPO = release ]]; then \
       yum -y install condor; \
     fi
 
+# Make a /proc dir in the sandbox condor uses to test singularity so we can test proc bind mounting
+# Workaround for https://opensciencegrid.atlassian.net/browse/HTCONDOR-1574
+RUN mkdir -p /usr/libexec/condor/singularity_test_sandbox/proc
+
 RUN git clone https://github.com/cvmfs/cvmfsexec /cvmfsexec \
  && cd /cvmfsexec \
  && ./makedist osg \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ ENV ITB=
 
 # Set this to empty to not send syslog remotely
 ENV ENABLE_REMOTE_SYSLOG=1
+# Set this to non-blank to use the prepare-job-hook to run Singularity jobs
+ENV CONTAINER_PILOT_USE_JOB_HOOK=
 
 # Previous args have gone out of scope
 ARG BASE_OSG_SERIES=3.6
@@ -116,6 +118,8 @@ RUN git clone --branch ${OSG_FLOCK_BRANCH} https://github.com/${OSG_FLOCK_REPO} 
  && install ospool-pilot/itb/lib/ospool-lib                             /gwms/client_group_itb/itb-ospool-lib \
  && install ospool-pilot/itb/pilot/singularity-extras                   /gwms/client_group_itb/itb-singularity-extras \
  && install job-wrappers/itb-default_singularity_wrapper.sh             /usr/sbin/itb-osgvo-singularity-wrapper \
+ && install ospool-pilot/itb/job/prepare-hook                           /gwms/client_group_itb/itb-prepare-hook \
+ && install ospool-pilot/itb/job/simple-job-wrapper.sh                  /usr/sbin/itb-simple-job-wrapper \
  # common files: \
  && install stashcp/stashcp                                             /gwms/client/stashcp \
  && install stashcp/stash_plugin                                        /usr/libexec/condor/stash_plugin \


### PR DESCRIPTION
Specifying `ITB=1` in the environment will cause the pilot to use the scripts from the `itb` frontend group, now including `additional-htcondor-config`. Config that's done in `additional-htcondor-config` will no longer be done directly in the pilot.

Setting `CONTAINER_PILOT_USE_JOB_HOOK=1` will additionally use the minimal job wrapper and job hook instead of the singularity job wrapper. The default is off but we can turn it on by default when we declare it production ready.

The singularity job wrapper is still used to run the `advertise-userenv` startd_cron.