### PR TITLE
SOFTWARE-5299: implemented OSG_PROJECT_RESTRICTION and OSPool tagging

### DIFF
--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -122,7 +122,7 @@ if [ "x$GLIDEIN_ResourceName" = "x" ]; then
     exit 1
 fi
 if [ "x$OSG_PROJECT_NAME" != "x" ]; then
-    export OSG_PROJECT_RESTRICTION="ProjectName == \"OSG_PROJECT_NAME\""
+    export OSG_PROJECT_RESTRICTION="ProjectName == \"$OSG_PROJECT_NAME\""
 fi
 if [ "x$GLIDEIN_Start_Extra" != "x" ]; then
     if (echo "$GLIDEIN_Start_Extra" | grep -i ProjectName) >/dev/null 2>&1; then

--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -128,6 +128,8 @@ if [ "x$GLIDEIN_Start_Extra" != "x" ]; then
     if (echo "$GLIDEIN_Start_Extra" | grep -i ProjectName) >/dev/null 2>&1; then
         echo "Using GLIDEIN_Start_Extra for limiting on ProjectName is discouraged. Please use OSG_PROJECT_NAME to restrict the pilot." 1>&2
     fi
+else
+    export GLIDEIN_Start_Extra="True"
 fi
 if [ "x$ACCEPT_JOBS_FOR_HOURS" = "x" ]; then
     export ACCEPT_JOBS_FOR_HOURS=336

--- a/50-main.config
+++ b/50-main.config
@@ -44,7 +44,8 @@ GLIDEIN_ContainerTag = "@CONTAINER_TAG@"
 STARTD_ATTRS = $(STARTD_ATTRS) GLIDEIN_Country GLIDEIN_Site GLIDEIN_ResourceName \
                WorkerGroupName IsOsgVoContainer GLIDEIN_ContainerTag \
                GLIDECLIENT_Group \
-               Is_ITB_Site
+               Is_ITB_Site \
+               START_EXTRA OSG_PROJECT_RESTRICTION
 
 # IsBlackHole is set in "additional-htcondor-config"
 # HasExcessiveLoad is set in "additional-htcondor-config"

--- a/50-main.config
+++ b/50-main.config
@@ -44,7 +44,8 @@ GLIDEIN_ContainerTag = "@CONTAINER_TAG@"
 STARTD_ATTRS = $(STARTD_ATTRS) GLIDEIN_Country GLIDEIN_Site GLIDEIN_ResourceName \
                WorkerGroupName IsOsgVoContainer GLIDEIN_ContainerTag \
                GLIDECLIENT_Group \
-               Is_ITB_Site
+               Is_ITB_Site \
+               OSPool
 
 # IsBlackHole is set in "additional-htcondor-config"
 # HasExcessiveLoad is set in "additional-htcondor-config"
@@ -65,7 +66,7 @@ START = (isUndefined(DaemonStartTime) || (time() - DaemonStartTime) < (MY.ACCEPT
         ($(CPUJOB_ON_GPUSLOT)) && \
         (isUndefined(TARGET.SingularityImage) || MY.SINGULARITY_START_CLAUSE) && \
         (TARGET.Want_MPI =!= True || MY.Has_MPI =?= True) && \
-        ($(START_EXTRA))
+        ($(START_EXTRA)) && (OSG_PROJECT_RESTRICTION ?: true)
 
 # Prefer certain types of jobs, for example GPU jobs if they can fit
 RANK = (TARGET.RequestGPUs ?: 0)

--- a/50-main.config
+++ b/50-main.config
@@ -44,8 +44,7 @@ GLIDEIN_ContainerTag = "@CONTAINER_TAG@"
 STARTD_ATTRS = $(STARTD_ATTRS) GLIDEIN_Country GLIDEIN_Site GLIDEIN_ResourceName \
                WorkerGroupName IsOsgVoContainer GLIDEIN_ContainerTag \
                GLIDECLIENT_Group \
-               Is_ITB_Site \
-               OSPool
+               Is_ITB_Site
 
 # IsBlackHole is set in "additional-htcondor-config"
 # HasExcessiveLoad is set in "additional-htcondor-config"
@@ -66,7 +65,7 @@ START = (isUndefined(DaemonStartTime) || (time() - DaemonStartTime) < (MY.ACCEPT
         ($(CPUJOB_ON_GPUSLOT)) && \
         (isUndefined(TARGET.SingularityImage) || MY.SINGULARITY_START_CLAUSE) && \
         (TARGET.Want_MPI =!= True || MY.Has_MPI =?= True) && \
-        ($(START_EXTRA)) && (OSG_PROJECT_RESTRICTION ?: true)
+        (START_EXTRA ?: true) && (OSG_PROJECT_RESTRICTION ?: true)
 
 # Prefer certain types of jobs, for example GPU jobs if they can fit
 RANK = (TARGET.RequestGPUs ?: 0)


### PR DESCRIPTION
Users can now set -e OSG_PROJECT_NAME="..." to restrict what projects the pilot will serve.

Using the old GLIDEIN_Start_Extra will result in a deprecation warning.

OSPool attribute is set accordingly - True if it is an unrestricted pilot to the production OSPool CMs, False otherwise.