### PR TITLE
Use osdf-client from RPMs instead of downloading our own from the osg-flock repo (OSPOOL-64)

### DIFF
--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -549,6 +549,14 @@ else
     filetransfer_plugins=$(condor_config_val FILETRANSFER_PLUGINS 2>/dev/null)
     if [[ $filetransfer_plugins != *${osdf_plugin}* ]]; then
         echo >&2 "Stash/OSDF file transfer plugin missing from plugins list; stash://, osdf:// URL support nonfunctional"
+    else
+        # Everything's OK. Get the version so we can advertise it.
+        osdf_plugin_version=$("$osdf_plugin" -classad | awk '/^PluginVersion / { print $3 }' | tr -d '"')
+        if [[ $osdf_plugin_version ]]; then
+            echo "STASH_PLUGIN_VERSION = \"$osdf_plugin_version\"" >> "$PILOT_CONFIG_FILE"
+            echo "OSDF_PLUGIN_VERSION = \"$osdf_plugin_version\"" >> "$PILOT_CONFIG_FILE"  # forward compat
+            echo "STARTD_ATTRS = $(STARTD_ATTRS) STASH_PLUGIN_VERSION OSDF_PLUGIN_VERSION" >> "$PILOT_CONFIG_FILE"
+        fi
     fi
 fi
 rm -f /tmp/stashcp-test.file /tmp/stashcp-debug.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -131,9 +131,7 @@ RUN git clone --branch ${OSG_FLOCK_BRANCH} https://github.com/${OSG_FLOCK_REPO} 
  && install ospool-pilot/itb/job/prepare-hook                           /gwms/client_group_itb/itb-prepare-hook \
  && install ospool-pilot/itb/job/simple-job-wrapper.sh                  /usr/sbin/itb-simple-job-wrapper \
  # common files: \
- && install stashcp/stashcp                                             /gwms/client/stashcp \
- && install stashcp/stash_plugin                                        /usr/libexec/condor/stash_plugin \
- && ln -snf /gwms/client/stashcp                                        /usr/bin/stashcp \
+ && install /usr/bin/stashcp                                            /gwms/client/stashcp \
  # advertise info \
  && echo "OSG_FLOCK_REPO = \"$OSG_FLOCK_REPO\""        >> /etc/condor/config.d/60-flock-sources.config \
  && echo "OSG_FLOCK_BRANCH = \"$OSG_FLOCK_BRANCH\""    >> /etc/condor/config.d/60-flock-sources.config \


### PR DESCRIPTION
Use the stash/osdf plugin 'shipped with' Condor instead of having a copy in the osg-flock repo. For the backfill containers this is the RPM from the OSG repos; for glideins, the condor tarball will contain it.

We still test it, it's just that instead of enabling it when the tests pass, we disable it when the tests fail.

This is temporary - I'll move the logic into the `additional-htcondor-config` script later.

https://opensciencegrid.atlassian.net/browse/OSPOOL-64