### PR TITLE
Fix bash escaping error for STARTD_ATTRS

### DIFF
--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -558,7 +558,7 @@ else
         if [[ $osdf_plugin_version ]]; then
             echo "STASH_PLUGIN_VERSION = \"$osdf_plugin_version\"" >> "$PILOT_CONFIG_FILE"
             echo "OSDF_PLUGIN_VERSION = \"$osdf_plugin_version\"" >> "$PILOT_CONFIG_FILE"  # forward compat
-            echo "STARTD_ATTRS = $(STARTD_ATTRS) STASH_PLUGIN_VERSION OSDF_PLUGIN_VERSION" >> "$PILOT_CONFIG_FILE"
+            echo "STARTD_ATTRS = \$(STARTD_ATTRS) STASH_PLUGIN_VERSION OSDF_PLUGIN_VERSION" >> "$PILOT_CONFIG_FILE"
         fi
     fi
 fi


### PR DESCRIPTION
The `$` symbol is not escaped, meaning the pilot addition dumps in a line which looks like this:
```
STARTD_ATTRS =  STASH_PLUGIN_VERSION OSDF_PLUGIN_VERSION
```

This does not inherit the prior settings of `STARTD_ATTRS`, meaning `GLIDEIN_Site` is not set.  This causes jobs to no longer be matched.