### PR TITLE
Don't install redhat-lsb-core on EL9: it doesn't exist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,12 +24,12 @@ RUN useradd osg \
  && mkdir -p ~osg/.condor \
  && yum -y install \
         osg-wn-client \
-        redhat-lsb-core \
         apptainer \
         attr \
         git \
         rsyslog rsyslog-gnutls python3-cryptography python3-requests \
         bind-utils \
+ && if [[ $BASE_OS != el9 ]]; then yum -y install redhat-lsb-core; fi \
  && yum clean all \
  && mkdir -p /etc/condor/passwords.d /etc/condor/tokens.d
 


### PR DESCRIPTION
Nothing provides lsb_release so if we have a script that uses it, it will have to be modified.
SOFTWARE-5538

This seems to be the only change necessary to build a pilot based on the opensciencegrid/software-base/3.6-el9-development image.