### PR TITLE
Add the environment variable `SINGULARITY_BIND_EXTRA` (SOFTWARE-5528)

### DIFF
--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -521,6 +521,11 @@ GLIDECLIENT_Group $GLIDECLIENT_Group
 GLIDEIN_Start_Extra $GLIDEIN_Start_Extra
 OSG_PROJECT_NAME $OSG_PROJECT_NAME
 EOF
+if [[ $SINGULARITY_BIND_EXTRA ]]; then
+    cat >>$glidein_config <<EOF
+GLIDEIN_SINGULARITY_BINDPATH $SINGULARITY_BIND_EXTRA
+EOF
+fi
 touch $condor_vars_file
 
 disable_osdf_plugin () {

--- a/Dockerfile
+++ b/Dockerfile
@@ -193,6 +193,9 @@ ENV ACCEPT_IDLE_MINUTES=30
 # Set this to restrict this pilot to only run jobs from a specific Project
 ENV OSG_PROJECT_NAME=
 
+# Additional paths to bind for Singularity jobs; same syntax as the -B option in singularity run
+ENV SINGULARITY_BIND_EXTRA=
+
 # Additional restrictions for your START expression
 ENV GLIDEIN_Start_Extra=
 


### PR DESCRIPTION
This provides a way of adding additional bind-mounts into Singularity jobs.  This is something we can already do in factory pilots with `GLIDEIN_SINGULARITY_BINDPATH`.

`SINGULARITY_BIND_EXTRA` adds the bind-mounts by setting `GLIDEIN_SINGULARITY_BINDPATH` in the glidein config; I didn't want to couple the behavior to the implementation which is why I gave it a different name.