### PR TITLE
GLIDEIN_ToRetire and GLIDEIN_ToDie

### DIFF
--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -134,6 +134,24 @@ if [ "x$GLIDEIN_Start_Extra" != "x" ]; then
 else
     export GLIDEIN_Start_Extra="True"
 fi
+if ! [[ "$ACCEPT_JOBS_FOR_HOURS" =~ ^[0-9]+$ ]]; then
+    echo "ACCEPT_JOBS_FOR_HOURS has to be a positive integer" 1>&2
+    exit 1
+else
+    if [ $ACCEPT_JOBS_FOR_HOURS -le 0 ]; then
+        echo "ACCEPT_JOBS_FOR_HOURS has to be a positive integer" 1>&2
+        exit 1
+    fi
+fi
+if ! [[ "$RETIREMENT_HOURS" =~ ^[0-9]+$ ]]; then
+    echo "RETIREMENT_HOURS has to be a positive integer" 1>&2
+    exit 1
+else
+    if [ $RETIREMENT_HOURS -le 0 ]; then
+        echo "RETIREMENT_HOURS has to be a positive integer" 1>&2
+        exit 1
+    fi
+fi
 
 
 #

--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -367,12 +367,19 @@ if is_true "$CONTAINER_PILOT_USE_JOB_HOOK" && [[ ! -e ${prepare_hook} ]]; then
     exit 1
 fi
 
+cat <<EOF
+This pilot will accept new jobs for $ACCEPT_JOBS_FOR_HOURS hours, and
+then let running jobs finish for $RETIREMENT_HOURS hours. To control
+this behavior, you may set the ACCEPT_JOBS_FOR_HOURS and
+RETIREMENT_HOURS environment variables.
+EOF
+
 # use GLIDEIN_ToRetire - this is for aligning with GWMS glideins
 NOW=$(date +'%s')
 GLIDEIN_ToRetire=$(($NOW + $ACCEPT_JOBS_FOR_HOURS * 60 * 60))
 
 # Give the instance 24 hours to finish up before exiting
-GLIDEIN_ToDie=$(($GLIDEIN_ToRetire + 24 * 60 * 60))
+GLIDEIN_ToDie=$(($GLIDEIN_ToRetire + $RETIREMENT_HOURS * 60 * 60))
 
 # to avoid collisions when ~ is shared, write the config file to /tmp
 export PILOT_CONFIG_FILE=$LOCAL_DIR/condor_config.pilot

--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -367,6 +367,13 @@ if is_true "$CONTAINER_PILOT_USE_JOB_HOOK" && [[ ! -e ${prepare_hook} ]]; then
     exit 1
 fi
 
+# use GLIDEIN_ToRetire - this is for aligning with GWMS glideins
+NOW=$(date +'%s')
+GLIDEIN_ToRetire=$(($NOW + $ACCEPT_JOBS_FOR_HOURS * 60 * 60))
+
+# Give the instance 24 hours to finish up before exiting
+GLIDEIN_ToDie=$(($GLIDEIN_ToRetire + 24 * 60 * 60))
+
 # to avoid collisions when ~ is shared, write the config file to /tmp
 export PILOT_CONFIG_FILE=$LOCAL_DIR/condor_config.pilot
 
@@ -404,8 +411,11 @@ OSG_SQUID_LOCATION = "$OSG_SQUID_LOCATION"
 ACCEPT_JOBS_FOR_HOURS = $ACCEPT_JOBS_FOR_HOURS
 ACCEPT_IDLE_MINUTES = $ACCEPT_IDLE_MINUTES
 
-STARTD_ATTRS = \$(STARTD_ATTRS) ACCEPT_JOBS_FOR_HOURS ACCEPT_IDLE_MINUTES
-MASTER_ATTRS = \$(MASTER_ATTRS) ACCEPT_JOBS_FOR_HOURS ACCEPT_IDLE_MINUTES
+GLIDEIN_ToRetire = $GLIDEIN_ToRetire
+GLIDEIN_ToDie = $GLIDEIN_ToDie
+
+STARTD_ATTRS = \$(STARTD_ATTRS) ACCEPT_JOBS_FOR_HOURS ACCEPT_IDLE_MINUTES GLIDEIN_ToRetire GLIDEIN_ToDie
+MASTER_ATTRS = \$(MASTER_ATTRS) ACCEPT_JOBS_FOR_HOURS ACCEPT_IDLE_MINUTES GLIDEIN_ToRetire GLIDEIN_ToDie
 
 # policy
 use policy : Hold_If_Memory_Exceeded

--- a/50-main.config
+++ b/50-main.config
@@ -56,7 +56,7 @@ STARTD_ATTRS = $(STARTD_ATTRS) GLIDEIN_Country GLIDEIN_Site GLIDEIN_ResourceName
 # Some attributes used (OSG_NODE_VALIDATED, IsBlackHole, HasExcessiveLoad, ...) might
 # not be used/defined by all VOs, so we explicitly check if they are defined before
 # using them as part of the START expression.
-START = (isUndefined(DaemonStartTime) || (time() - DaemonStartTime) < (MY.ACCEPT_JOBS_FOR_HOURS*60*60)) && \
+START = (time() < GLIDEIN_ToRetire) && \
         (isUndefined(MY.OSG_NODE_VALIDATED) || MY.OSG_NODE_VALIDATED) && \
         (isUndefined(IsBlackHole) || IsBlackHole == False) && \
         (isUndefined(HasExcessiveLoad) || HasExcessiveLoad == False) && \
@@ -85,7 +85,7 @@ STARTD_NOCLAIM_SHUTDOWN = $(ACCEPT_IDLE_MINUTES) * 60
 # Have the master exit if the startd isn't around and it's been given more
 # than sixty seconds to show up.  (We could avoid having a timeout if we
 # were sure that START_StartTime was undefined before its first start.)
-MASTER.DAEMON_SHUTDOWN_FAST = ( STARTD_StartTime == 0 ) && ((CurrentTime - DaemonStartTime) > 60)
+MASTER.DAEMON_SHUTDOWN_FAST = ((STARTD_StartTime == 0) && ((CurrentTime - DaemonStartTime) > 60)) || (time() > GLIDEIN_ToDie)
 
 # callout to a script when the master exits
 DEFAULT_MASTER_SHUTDOWN_SCRIPT = /etc/condor/master_shutdown.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -188,7 +188,7 @@ ENV CVMFS_QUOTA_LIMIT=
 # How many hours to accept new jobs for
 ENV ACCEPT_JOBS_FOR_HOURS=336
 # Hours to let running jobs finish during retirement
-env RETIREMENT_HOURS=24
+ENV RETIREMENT_HOURS=24
 # Minutes to wait before shutting down due to lack of jobs
 ENV ACCEPT_IDLE_MINUTES=30
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -187,6 +187,8 @@ ENV CVMFS_QUOTA_LIMIT=
 
 # How many hours to accept new jobs for
 ENV ACCEPT_JOBS_FOR_HOURS=336
+# Hours to let running jobs finish during retirement
+env RETIREMENT_HOURS=24
 # Minutes to wait before shutting down due to lack of jobs
 ENV ACCEPT_IDLE_MINUTES=30
 


### PR DESCRIPTION
This adds two new attributes: `GLIDEIN_ToRetire` and `GLIDEIN_ToDie`. We need these to align with the GWMS glideins in the pool. The attributes will not only be used within the container, but also for monitoring (OSPOOL-72 for example) and potentially for scheduling decisions (when we implement better logic for `JobDurationCategory`).