### PR TITLE
Handle JobDurationCategory=Long

### DIFF
--- a/50-main.config
+++ b/50-main.config
@@ -57,6 +57,7 @@ STARTD_ATTRS = $(STARTD_ATTRS) GLIDEIN_Country GLIDEIN_Site GLIDEIN_ResourceName
 # not be used/defined by all VOs, so we explicitly check if they are defined before
 # using them as part of the START expression.
 START = (time() < GLIDEIN_ToRetire) && \
+        (ifThenElse(TARGET.JobDurationCategory =?= "Long", GLIDEIN_ToDie - time() > 144000, True)) && \
         (isUndefined(MY.OSG_NODE_VALIDATED) || MY.OSG_NODE_VALIDATED) && \
         (isUndefined(IsBlackHole) || IsBlackHole == False) && \
         (isUndefined(HasExcessiveLoad) || HasExcessiveLoad == False) && \


### PR DESCRIPTION
Make sure we only schedule `JobDurationCategory = "Long"` jobs on pilots which have enough runtime left to finish the job. See:

https://portal.osg-htc.org/documentation/htc_workloads/workload_planning/jobdurationcategory/

We already have a similar setup in for the GWMS pilots:

https://github.com/opensciencegrid/osg-flock/blob/master/ospool.osg-htc.org/production/frontend-template.xml#L55-L57
