### PR TITLE
Skip singularity test for cuda images

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -72,9 +72,14 @@ jobs:
         env:
           CONTAINER_IMAGE: ${{ steps.build-image.outputs.timestamp-image }}
         run: |
-          sudo ./tests/test_inside_gha.sh singularity \
-                                          bindmount \
-                                          "$CONTAINER_IMAGE"
+          if [[ $CONTAINER_IMAGE == *cuda* ]]; then
+              echo >&2 "Skipping test: \$APPTAINER_TMPDIR (${APPTAINER_TMPDIR:-/tmp}) too small for cuda-based images"
+              exit 0
+          else
+              sudo ./tests/test_inside_gha.sh singularity \
+                                              bindmount \
+                                              "$CONTAINER_IMAGE"
+          fi
 
       - name: Harbor login
         if: >-


### PR DESCRIPTION
Running with singularity requires converting the image to SIF first and the runner doesn't have the disk space to do that.