### PR TITLE
Enable OSG 23 release/testing images (SOFTWARE-5673)

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -26,16 +26,6 @@ jobs:
           # OSG 23 should default to EL9
           - os: 'al8'
             osg_series: '23'
-          # FIXME: enable these when we have OSG 23 packages in testing/release
-          - osg_series: '23'
-            repo: 'testing'
-          - osg_series: '23'
-            repo: 'release'
-        # FIXME: Remove this upon release of OSG 23
-        include:
-          - os: cuda_11_8_0
-            osg_series: '23'
-            repo: development
     steps:
       - id: custom-image-name
         env:

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -26,6 +26,10 @@ jobs:
           # OSG 23 should default to EL9
           - os: 'al8'
             osg_series: '23'
+          # FIXME: disable OSG 23 dev until we have fixed the mash
+          # cache + signed RPMs issue in the prod repo
+          - osg_series: '23'
+            repo: 'development'
     steps:
       - id: custom-image-name
         env:


### PR DESCRIPTION
Also disable CUDA 23 dev images as we only needed them to initially
verify OSG 23 worked with the base CUDA image