### PR TITLE
tests: use 126 as the ABORT_CODE

### DIFF
--- a/tests/test_inside_gha.sh
+++ b/tests/test_inside_gha.sh
@@ -15,7 +15,7 @@ function usage {
     echo "Usage: $0 <docker|singularity> <bindmount|cvmfsexec>"
 }
 
-ABORT_CODE=127
+ABORT_CODE=126
 SINGULARITY_OUTPUT=$(mktemp)
 PILOT_DIR=$(mktemp -d)
 function start_singularity_backfill {


### PR DESCRIPTION
exit code 127 is the return code from the shell on a 'command not found'