### PR TITLE
If POOL is a hostname or host:port then use it as a central manager as opposed to bailing out

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -224,3 +224,7 @@ ENV ENABLE_REMOTE_SYSLOG=true
 # Use ITB versions of scripts and connect to the ITB pool
 ENV ITB=false
 
+# The pool to join; this can be 'itb-ospool', 'prod-ospool', 'prod-path-facility',
+# 'dev-path-facility', or the hostname or host:port of a central manager.
+# If it's set to 'ospool', then it will use 'itb-ospool'  or 'prod-ospool' depending on $ITB.
+ENV POOL=ospool


### PR DESCRIPTION
We don't specify a separate CCB_ADDRESS in that case; also we disable remote syslog. Also toss in a special case that if POOL is "ospool" then we choose prod-ospool or itb-ospool depending on $ITB.  I like this better than having that behavior be implicit if POOL is blank.

(SOFTWARE-5383)