### PR TITLE
Better check for making sure no CVMFSEXEC_REPOS were specified

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,7 +65,7 @@ if [[ -d $config_repo ]]; then
     echo "OSG CVMFS already available (perhaps via bind-mount),"
     echo "skipping cvmfsexec."
     exec "$@"
-elif [[ -z $CVMFSEXEC_REPOS ]]; then
+elif [[ ! $CVMFSEXEC_REPOS =~ [a-z]+ ]]; then
     echo "No CVMFS repos requested, skipping cvmfsexec."
     exec "$@"
 fi


### PR DESCRIPTION
Make sure there is at least one letter in $CVMFSEXEC_REPOS so we don't think a repo is specified for a string like ` ` or `,` which could occur if $CVMFSEXEC_REPOS is built up by a script, for example.