### PR TITLE
Allow adding arbitrary extra STARTD attributes (SOFTWARE-5324)

### DIFF
--- a/10-setup-htcondor.sh
+++ b/10-setup-htcondor.sh
@@ -651,7 +651,7 @@ use POLICY : WANT_HOLD_IF( DISK_EXCEEDED, \$(HOLD_SUBCODE_DISK_EXCEEDED:104), \$
 END
 fi
 
-# last step - interpret the condor_vars
+# interpret the condor_vars
 set +x
 while read line
 do
@@ -664,6 +664,15 @@ MASTER_ATTRS = \$(MASTER_ATTRS), $glidein_variables
 STARTD_ATTRS = \$(STARTD_ATTRS), $glidein_variables
 STARTER_JOB_ENVIRONMENT = "$job_env"
 EOF
+
+
+
+# Read a file for arbitrary additional attributes to insert into the startd ad
+extra_attributes_file=/etc/osg/extra-attributes.cfg
+if [[ -f $extra_attributes_file ]]; then
+    /usr/local/sbin/add-extra-attributes "$extra_attributes_file" "$PILOT_CONFIG_FILE"
+fi
+
 
 # In this container, we replace ldconfig with a wrapper; otherwise, when the nvidia hooks
 # run they will run ldconfig and have it fail (it can't write into /etc), resulting

--- a/Dockerfile
+++ b/Dockerfile
@@ -170,6 +170,7 @@ RUN chmod 04755 /usr/bin/launch_rsyslogd && \
     ln -sf /usr/share/zoneinfo/UTC /etc/localtime
 
 COPY supervisord_startup.sh /usr/local/sbin/
+COPY --chmod=0755 sbin/* /usr/local/sbin/
 
 WORKDIR /pilot
 # We need an ENTRYPOINT so we can use cvmfsexec with any command (such as bash for debugging purposes)

--- a/sbin/add-extra-attributes
+++ b/sbin/add-extra-attributes
@@ -1,0 +1,66 @@
+#!/usr/bin/python3
+"""Read a file containing arbitrary extra attributes to advertise in the startd,
+and add those extra attributes to the pilot config file.
+"""
+# TODO Does not support multi-line strings or escaping newlines
+
+from argparse import ArgumentParser, FileType
+import io
+import re
+import sys
+from typing import Dict
+
+
+def complain(*args, **kwargs):
+    """Print something to stderr. A wrapper around print()"""
+    kwargs['file'] = sys.stderr
+    return print(*args, **kwargs)
+
+
+def read_attributes(attribs_fh: io.TextIOBase) -> Dict:
+    """Read attributes from a filehandle to a dict"""
+    attributes = {}
+    for idx, line in enumerate(attribs_fh):
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        try:
+            key, value = line.split("=", 1)
+        except ValueError:
+            complain(f"skipping invalid line {idx+1} ({line!r})")
+            continue
+        if not re.match(r"[A-Za-z_][A-Za-z0-9_]*", key):
+            print(f"line {idx+1} has invalid key ({key!r})",
+                  file=sys.stderr)
+            continue
+        attributes[key] = value
+    return attributes
+
+
+def write_config(attributes: Dict, config_fh: io.TextIOBase):
+    """Write attributes and a STARTD_ATTRS line to condor config, based on a dict"""
+    keys = sorted(attributes)
+    for key in keys:
+        config_fh.write(f"{key} = {attributes[key]}\n")
+
+    config_fh.write(f'STARTD_ATTRS = $(STARTD_ATTRS) {" ".join(keys)}\n')
+
+
+def main():
+    """Main function"""
+    parser = ArgumentParser()
+    parser.add_argument("attributes_file", type=FileType("rt"),
+                        help="The file to read extra attributes from")
+    parser.add_argument("pilot_config_file", type=FileType("at"),
+                        help="The pilot config file to append startd attributes to")
+    args = parser.parse_args()
+
+    attributes = read_attributes(args.attributes_file)
+    write_config(attributes, args.pilot_config_file)
+
+
+try:
+    sys.exit(main())
+except RuntimeError as err:
+    print(err, file=sys.stderr)
+    sys.exit(1)


### PR DESCRIPTION
If you bind-mount a file containing `key=value` pairs to `/etc/osg/extra-attributes.cfg` then those attributes will be added to STARTD_ATTRS.  A new script, `/usr/local/sbin/add-extra-attributes`, parses the file and does some light validation, then appends the attributes to the pilot config file.

I put the script in a new sbin/ directory so it doesn't get mixed in with all the other random files we have; I want to reorganize the repo in a later PR to put the various config and script files in directories as opposed to having them all be at the top level.