### PR TITLE
Use tini when using cvmfsexec to handle signal propagation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN useradd osg \
         rsyslog rsyslog-gnutls python3-cryptography python3-requests \
         bind-utils \
         socat \
+        tini \
  && if [[ $BASE_OS != el9 ]]; then yum -y install redhat-lsb-core; fi \
  && yum clean all \
  && mkdir -p /etc/condor/passwords.d /etc/condor/tokens.d

--- a/sbin/entrypoint.sh
+++ b/sbin/entrypoint.sh
@@ -103,4 +103,10 @@ if [ "x$SUPERVISORD_RESTART_POLICY" != "x" ]; then
     add_or_replace "$htcondor_supervisord_config" autorestart "${SUPERVISORD_RESTART_POLICY}"
 fi
 
-exec $cvmfsexec_root/cvmfsexec -N $CVMFSEXEC_REPOS -- "$@"
+if [[ $1 == /usr/local/sbin/supervisord_startup.sh ]]; then
+    # If we're starting the pilot then run cvmfsexec under tini so signals are propagated
+    exec tini $cvmfsexec_root/cvmfsexec -- -N $CVMFSEXEC_REPOS -- "$@"
+else
+    # If we're exec'ing in or running an alternate command, then just run cvmfsexec.
+    exec $cvmfsexec_root/cvmfsexec -N $CVMFSEXEC_REPOS -- "$@"
+fi


### PR DESCRIPTION
We have an issue where if the container uses cvmfsexec to mount repos, then a SIGTERM (as sent by docker stop) won't shut it down and we have to wait for docker to time out and send SIGKILL.

This is because cvmfsexec is pid 1 inside the container, which is special, and we have to have it explicitly forward the signals to the child processes.  If we don't use cvmfsexec, then supervisord is pid 1, and signal propagation is handled.

This commit adds `tini`, a small init system, to handle signal propagation; it is only used when we're using cvmfsexec.