### PR TITLE
Exit out if 'exec' fails

### DIFF
--- a/sbin/entrypoint.sh
+++ b/sbin/entrypoint.sh
@@ -7,6 +7,20 @@ cvmfsexec_local_config=$cvmfsexec_root/dist/etc/cvmfs/default.local
 htcondor_supervisord_config=/etc/supervisord.d/10-htcondor.conf
 
 
+safe_exec () {
+    local cmd
+    cmd=("$@")
+    # apptainer run sometimes sets the first argument to '--' which is a syntax error
+    if [[ ${cmd[0]} = -* ]]; then
+        unset cmd[0]
+        cmd=("${cmd[@]}")  # fix indices
+    fi
+    exec "${cmd[@]}"
+    # we should not get here:
+    fail "Exec failed with $? on command '${cmd[*]}'"
+}
+
+
 add_or_replace () {
     local file="$1"
     local var="$2"
@@ -64,10 +78,10 @@ is_true () {
 if [[ -d $config_repo ]]; then
     echo "OSG CVMFS already available (perhaps via bind-mount),"
     echo "skipping cvmfsexec."
-    exec "$@"
+    safe_exec "$@"
 elif [[ ! $CVMFSEXEC_REPOS =~ [a-z]+ ]]; then
     echo "No CVMFS repos requested, skipping cvmfsexec."
-    exec "$@"
+    safe_exec "$@"
 fi
 CVMFSEXEC_REPOS=$(tr -s ',' ' ' <<<"$CVMFSEXEC_REPOS")
 
@@ -105,8 +119,8 @@ fi
 
 if [[ $1 == /usr/local/sbin/supervisord_startup.sh ]]; then
     # If we're starting the pilot then run cvmfsexec under tini so signals are propagated
-    exec tini $cvmfsexec_root/cvmfsexec -- -N $CVMFSEXEC_REPOS -- "$@"
+    safe_exec tini $cvmfsexec_root/cvmfsexec -- -N $CVMFSEXEC_REPOS -- "$@"
 else
     # If we're exec'ing in or running an alternate command, then just run cvmfsexec.
-    exec $cvmfsexec_root/cvmfsexec -N $CVMFSEXEC_REPOS -- "$@"
+    safe_exec $cvmfsexec_root/cvmfsexec -N $CVMFSEXEC_REPOS -- "$@"
 fi

--- a/sbin/entrypoint.sh
+++ b/sbin/entrypoint.sh
@@ -11,7 +11,7 @@ safe_exec () {
     local cmd
     cmd=("$@")
     # apptainer run sometimes sets the first argument to '--' which is a syntax error
-    if [[ ${cmd[0]} = -* ]]; then
+    if [[ ${cmd[0]} = '--' ]]; then
         unset cmd[0]
         cmd=("${cmd[@]}")  # fix indices
     fi

--- a/sbin/entrypoint.sh
+++ b/sbin/entrypoint.sh
@@ -8,16 +8,9 @@ htcondor_supervisord_config=/etc/supervisord.d/10-htcondor.conf
 
 
 safe_exec () {
-    local cmd
-    cmd=("$@")
-    # apptainer run sometimes sets the first argument to '--' which is a syntax error
-    if [[ ${cmd[0]} = '--' ]]; then
-        unset cmd[0]
-        cmd=("${cmd[@]}")  # fix indices
-    fi
-    exec "${cmd[@]}"
+    exec "$@"
     # we should not get here:
-    fail "Exec failed with $? on command '${cmd[*]}'"
+    fail "Exec failed with $? on command '$*'"
 }
 
 


### PR DESCRIPTION
I ran into two issues while trying to use this image with `apptainer run`:
- `apptainer run` put `--` into the first argument, causing `exec "$@"` to fail because it wasn't a real option
- the exec command failing did _not_ cause the script to stop