### PR TITLE
Delete quotes in/around CVMFSEXEC_REPOS

### DIFF
--- a/sbin/entrypoint.sh
+++ b/sbin/entrypoint.sh
@@ -77,7 +77,7 @@ elif [[ ! $CVMFSEXEC_REPOS =~ [a-z]+ ]]; then
     safe_exec "$@"
 fi
 CVMFSEXEC_REPOS=$(tr -s ',' ' ' <<<$CVMFSEXEC_REPOS)
-CVMFSEXEC_REPOS=$(tr -d '"'"'" <<<$CMVFSEXEC_REPOS)  # delete single and double quotes (docker envfiles treat quotes literally)
+CVMFSEXEC_REPOS=$(tr -d '"'"'" <<<$CVMFSEXEC_REPOS)  # delete single and double quotes (docker envfiles treat quotes literally)
 
 cd "$cvmfsexec_root" || \
     fail "Couldn't enter $cvmfsexec_root"

--- a/sbin/entrypoint.sh
+++ b/sbin/entrypoint.sh
@@ -77,6 +77,7 @@ elif [[ ! $CVMFSEXEC_REPOS =~ [a-z]+ ]]; then
     safe_exec "$@"
 fi
 CVMFSEXEC_REPOS=$(tr -s ',' ' ' <<<"$CVMFSEXEC_REPOS")
+CVMFSEXEC_REPOS=$(tr -d '"'"'" <<<"$CMVFSEXEC_REPOS")  # delete single and double quotes (docker envfiles treat quotes literally)
 
 cd "$cvmfsexec_root" || \
     fail "Couldn't enter $cvmfsexec_root"

--- a/sbin/entrypoint.sh
+++ b/sbin/entrypoint.sh
@@ -76,8 +76,8 @@ elif [[ ! $CVMFSEXEC_REPOS =~ [a-z]+ ]]; then
     echo "No CVMFS repos requested, skipping cvmfsexec."
     safe_exec "$@"
 fi
-CVMFSEXEC_REPOS=$(tr -s ',' ' ' <<<"$CVMFSEXEC_REPOS")
-CVMFSEXEC_REPOS=$(tr -d '"'"'" <<<"$CMVFSEXEC_REPOS")  # delete single and double quotes (docker envfiles treat quotes literally)
+CVMFSEXEC_REPOS=$(tr -s ',' ' ' <<<$CVMFSEXEC_REPOS)
+CVMFSEXEC_REPOS=$(tr -d '"'"'" <<<$CMVFSEXEC_REPOS)  # delete single and double quotes (docker envfiles treat quotes literally)
 
 cd "$cvmfsexec_root" || \
     fail "Couldn't enter $cvmfsexec_root"


### PR DESCRIPTION
People passing in env vars via a docker --env-file may be surprised to learn that quotes are passed through literally.  Handle that case by just deleting the quotes.