### PR TITLE
Shorten GitHub action names so the checks don't get chopped off in the web interface

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -25,7 +25,7 @@ jobs:
             image: 'osg-htc/ospool-ep'
           - series: '23'
             image: 'opensciencegrid/osgvo-docker-pilot'
-        platform: ['linux/amd64','linux/arm64']
+        arch: ['amd64','arm64']
         exclude:
           # cuda builds take a super long time; only do one of them
           - os: cuda_11_8_0
@@ -56,7 +56,7 @@ jobs:
           osg_series: ${{ matrix.osg_series.series }}
           osg_repo: ${{ matrix.repo }}
           base_os: ${{ matrix.os }}
-          platform: ${{ matrix.platform }}
+          platform: linux/${{ matrix.arch }}
           output_image: ${{ steps.custom-image-name.outputs.output_image }}
           timestamp: ${{ steps.custom-image-name.outputs.timestamp }}
 
@@ -64,12 +64,12 @@ jobs:
       - name: Prepare CVMFS
         # TODO: For all tests, GHA currently only supports amd64 runners. We will need
         # to re-enable tests on arm64 when ARM runners become available.
-        if: ${{ matrix.platform == 'linux/amd64' }}
+        if: ${{ matrix.arch == 'amd64' }}
         run: |
           sudo ./tests/setup_cvmfs.sh
 
       - name: Docker + CVMFS bindmount
-        if: ${{ matrix.platform == 'linux/amd64' }}
+        if: ${{ matrix.arch == 'amd64' }}
         id: test-docker-cvmfs
         env:
           CONTAINER_IMAGE: ${{ steps.build-image.outputs.timestamp-image }}
@@ -79,7 +79,7 @@ jobs:
                                           "$CONTAINER_IMAGE"
 
       - name: Docker + cvmfsexec        
-        if: ${{ matrix.platform == 'linux/amd64' }}
+        if: ${{ matrix.arch == 'amd64' }}
         id: test-docker-cvmfsexec
         env:
           CONTAINER_IMAGE: ${{ steps.build-image.outputs.timestamp-image }}
@@ -89,7 +89,7 @@ jobs:
                                           "$CONTAINER_IMAGE"
 
       - name: Singularity + CVMFS bindmount
-        if: ${{ matrix.platform == 'linux/amd64' }}
+        if: ${{ matrix.arch == 'amd64' }}
         id: test-singularity-cvmfs
         env:
           CONTAINER_IMAGE: ${{ steps.build-image.outputs.timestamp-image }}
@@ -117,7 +117,7 @@ jobs:
           osg_series: ${{ matrix.osg_series.series }}
           osg_repo: ${{ matrix.repo }}
           base_os: ${{ matrix.os }}
-          platform: ${{ matrix.platform }}
+          platform: linux/${{ matrix.arch }}
           base_tag: ${{ steps.custom-image-name.outputs.base_tag }}
           timestamp: ${{ steps.custom-image-name.outputs.timestamp }}
           output_image: ${{ steps.custom-image-name.outputs.output_image }}
@@ -143,7 +143,7 @@ jobs:
           osg_series: ${{ matrix.osg_series.series }}
           osg_repo: ${{ matrix.repo }}
           base_os: ${{ matrix.os }}
-          platform: ${{ matrix.platform }}
+          platform: linux/${{ matrix.arch }}
           base_tag: ${{ steps.custom-image-name.outputs.base_tag }}
           timestamp: ${{ steps.custom-image-name.outputs.timestamp }}
           output_image: ${{ steps.custom-image-name.outputs.output_image }}

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -148,7 +148,7 @@ jobs:
           timestamp: ${{ steps.custom-image-name.outputs.timestamp }}
           output_image: ${{ steps.custom-image-name.outputs.output_image }}
 
-  mrg-manif:
+  merge-manifests:
     runs-on: ubuntu-22.04
     if: >-
       github.ref == 'refs/heads/master' &&

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -1,4 +1,4 @@
-name: Build and test container images
+name: B&T images
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-images:
+  build:
     runs-on: ubuntu-22.04
     # Continue to the push/tag step even if some build matrix combos fail
     # Check that all arch artifacts are present in the push/tag step
@@ -148,14 +148,14 @@ jobs:
           timestamp: ${{ steps.custom-image-name.outputs.timestamp }}
           output_image: ${{ steps.custom-image-name.outputs.output_image }}
 
-  merge-manifests:
+  mrg-manif:
     runs-on: ubuntu-22.04
     if: >-
       github.ref == 'refs/heads/master' &&
       github.event_name != 'pull_request' &&
       contains(fromJson('["opensciencegrid","osg-htc"]'), github.repository_owner)
     needs:
-      - build-images
+      - build
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION

![Screenshot 2025-02-19 180207](https://github.com/user-attachments/assets/385c682e-e0d7-4b69-bf2b-188467bc6e05)

I cannot tell which of our image builds failed because the text gets chopped off.  Shorten the action names so I can see the matrix elements.