### PR TITLE
Backversion cvmfsexec to get newer CVMFS version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN if [[ $BASE_YUM_REPO = release ]]; then \
 RUN mkdir -p /usr/libexec/condor/singularity_test_sandbox/proc
 
 # CVMFSEXEC_BRANCH=TAGGED means use the highest versioned tag
-ARG CVMFSEXEC_BRANCH=TAGGED
+ARG CVMFSEXEC_BRANCH=4.44
 RUN git clone https://github.com/cvmfs/cvmfsexec /cvmfsexec \
  && cd /cvmfsexec \
  && if [[ $CVMFSEXEC_BRANCH = TAGGED ]]; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,8 @@ RUN if [[ $BASE_YUM_REPO = release ]]; then \
 RUN mkdir -p /usr/libexec/condor/singularity_test_sandbox/proc
 
 # CVMFSEXEC_BRANCH=TAGGED means use the highest versioned tag
-ARG CVMFSEXEC_BRANCH=4.44
+# Avoid CVMFS 4.45 because it breaks the installer
+ARG CVMFSEXEC_BRANCH=v4.44
 RUN git clone https://github.com/cvmfs/cvmfsexec /cvmfsexec \
  && cd /cvmfsexec \
  && if [[ $CVMFSEXEC_BRANCH = TAGGED ]]; then \


### PR DESCRIPTION
Dave says that 4.45 appears to break the installer so we're getting
cvmfs-2.10 instead of cvmfs-2.12.6