### PR TITLE
Use the latest cvmfsexec version again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,8 +53,7 @@ RUN if [[ $BASE_YUM_REPO = release ]]; then \
 RUN mkdir -p /usr/libexec/condor/singularity_test_sandbox/proc
 
 # CVMFSEXEC_BRANCH=TAGGED means use the highest versioned tag
-# Avoid CVMFS 4.45 because it breaks the installer
-ARG CVMFSEXEC_BRANCH=v4.44
+ARG CVMFSEXEC_BRANCH=TAGGED
 RUN git clone https://github.com/cvmfs/cvmfsexec /cvmfsexec \
  && cd /cvmfsexec \
  && if [[ $CVMFSEXEC_BRANCH = TAGGED ]]; then \


### PR DESCRIPTION
This was fixed in v4.46, specifically
https://github.com/cvmfs/cvmfsexec/pull/111