### PR TITLE
Handle SIGTERM and SIGINT with condor_off, allow for off strategies

### DIFF
--- a/10-htcondor.conf
+++ b/10-htcondor.conf
@@ -1,7 +1,12 @@
 [program:condor_master]
 command=/usr/local/sbin/condor_master_wrapper
-autorestart=unexpected
+autorestart=false
 startsecs=60
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 redirect_stderr=true
+
+; wait for condor_off peaceful/graceful to finish
+stopsignal=TERM
+stopwaitsecs=86400
+stopasgroup=false

--- a/50-main.config
+++ b/50-main.config
@@ -25,7 +25,8 @@ TOKENS = True
 SEC_DEFAULT_AUTHENTICATION_METHODS = IDTOKENS,PASSWORD,FS
 SEC_CLIENT_AUTHENTICATION_METHODS = IDTOKENS,FS
 
-ALLOW_ADMINISTRATOR = condor_pool@*/*
+# allow condor_off from the local user
+ALLOW_ADMINISTRATOR = condor_pool@*/* osg@$(HOSTNAME)
 
 use feature : GPUs
 # dynamic slots
@@ -33,6 +34,9 @@ SLOT_TYPE_1 = cpus=100%,gpus=100%,disk=100%,swap=100%
 SLOT_TYPE_1_PARTITIONABLE = TRUE
 NUM_SLOTS = 1
 NUM_SLOTS_TYPE_1 = 1
+
+# for graceful shutdown, give time for jobs to finish before exiting
+MaxJobRetirementTime = 86400
 
 # make it look like a gwms glidein
 GLIDEIN_Country = "US"

--- a/50-main.config
+++ b/50-main.config
@@ -64,7 +64,7 @@ STARTD_ATTRS = $(STARTD_ATTRS) GLIDEIN_Country GLIDEIN_Site GLIDEIN_ResourceName
 # For GPU containers, we check if we can fit some CPU-only jobs with RoomForCPUOnlyJobs
 START = (time() < GLIDEIN_ToRetire) && \
         (ifThenElse(TARGET.JobDurationCategory =?= "Long", GLIDEIN_ToDie - time() > 144000, True)) && \
-        (isUndefined(MY.OSG_NODE_VALIDATED) || MY.OSG_NODE_VALIDATED) && \
+        (MY.OSG_NODE_VALIDATED) && \
         (isUndefined(IsBlackHole) || IsBlackHole == False) && \
         (isUndefined(HasExcessiveLoad) || HasExcessiveLoad == False) && \
         ((DESIRED_Sites=?=undefined) || stringListMember(GLIDEIN_Site,DESIRED_Sites,",")) && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,11 +44,15 @@ RUN useradd osg \
 # Pull HTCondor from the proper repo. For "release" we need to use
 # osg-upcoming-testing to meet the patch tuesday requirements.
 RUN if [[ $BASE_YUM_REPO = release ]]; then \
-      yum -y --enablerepo=osg-upcoming-testing swap pelican pelican-debug && \
-      yum -y --enablerepo=osg-upcoming-testing install condor; \
+      yum -y --enablerepo=osg-upcoming-testing install condor && \
+      if /usr/local/bin/pkg-cmp-gt.sh condor 23.10.26; then \
+        yum -y --enablerepo=osg-upcoming-testing swap pelican pelican-debug; \
+      fi; \
     else \
-      yum -y swap pelican pelican-debug && \
-      yum -y install condor; \
+      yum -y install condor && \
+      if /usr/local/bin/pkg-cmp-gt.sh condor 23.10.26; then \
+        yum -y swap pelican pelican-debug; \
+      fi; \
     fi
 
 # Install an alternate back-version of apptainer with support for registry mirrors,

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN useradd osg \
         bind-utils \
         socat \
         tini \
+        delve \
  && if [[ $BASE_OS != el9 ]]; then yum -y install redhat-lsb-core; fi \
  && yum clean all \
  && mkdir -p /etc/condor/passwords.d /etc/condor/tokens.d

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,9 +44,11 @@ RUN useradd osg \
 # Pull HTCondor from the proper repo. For "release" we need to use
 # osg-upcoming-testing to meet the patch tuesday requirements.
 RUN if [[ $BASE_YUM_REPO = release ]]; then \
-      yum -y --enablerepo=osg-upcoming-testing install condor; \
+      yum -y --enablerepo=osg-upcoming-testing install condor \
+                                                       pelican-debug; \
     else \
-      yum -y install condor; \
+      yum -y install condor \
+                     pelican-debug;\
     fi
 
 # Install an alternate back-version of apptainer with support for registry mirrors,

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,11 +44,11 @@ RUN useradd osg \
 # Pull HTCondor from the proper repo. For "release" we need to use
 # osg-upcoming-testing to meet the patch tuesday requirements.
 RUN if [[ $BASE_YUM_REPO = release ]]; then \
-      yum -y --enablerepo=osg-upcoming-testing install condor \
-                                                       pelican-debug; \
+      yum -y --enablerepo=osg-upcoming-testing swap pelican pelican-debug && \
+      yum -y --enablerepo=osg-upcoming-testing install condor; \
     else \
-      yum -y install condor \
-                     pelican-debug;\
+      yum -y swap pelican pelican-debug && \
+      yum -y install condor; \
     fi
 
 # Install an alternate back-version of apptainer with support for registry mirrors,

--- a/sbin/condor_master_wrapper
+++ b/sbin/condor_master_wrapper
@@ -1,5 +1,30 @@
 #!/bin/bash
 
+# Function to handle SIGTERM
+function exit_trap() {
+    if [ "X$SHUTDOWN_STRATEGY" = "Xpeaceful" ]; then
+        echo "Shutting down HTCondor peacefully - wait indefinitely for all jobs to finish"
+        /usr/sbin/condor_off -peaceful -startd
+    elif [ "X$SHUTDOWN_STRATEGY" = "Xgraceful" ]; then
+        echo "Shutting down HTCondor gracefully - wait for 24 hours for jobs to finish"
+        /usr/sbin/condor_off -graceful -startd
+    else
+        echo "Shutting down HTCondor fast - killing jobs"
+        /usr/sbin/condor_off -fast -startd
+    fi
+}
 
-exec /usr/sbin/condor_master -f
+trap exit_trap SIGTERM SIGINT
+
+/usr/sbin/condor_master -f &
+master_pid=$!
+
+# wait for condor_master forever, exiting is controlled by
+# condor_off in the trap above
+while kill -0 "$master_pid" 2>/dev/null; do
+    sleep 10
+done
+wait "$master_pid"
+
+exit 0
 

--- a/sbin/condor_master_wrapper
+++ b/sbin/condor_master_wrapper
@@ -10,7 +10,7 @@ function exit_trap() {
         /usr/sbin/condor_off -graceful -startd
     else
         echo "Shutting down HTCondor fast - killing jobs"
-        /usr/sbin/condor_off -fast -startd
+        /usr/sbin/condor_off -fast -master
     fi
 }
 

--- a/sbin/startd_addr.sh
+++ b/sbin/startd_addr.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+CONDOR_LOGDIR=/pilot/log
+
+function condor_version_in_range {
+    local minimum maximum
+    minimum=${1:?minimum not provided to condor_version_in_range}
+    maximum=${2:-99.99.99}
+
+    local condor_version
+    condor_version=$(condor_version | awk '/CondorVersion/ {print $2}')
+    python3 -c '
+import sys
+minimum = [int(x) for x in sys.argv[1].split(".")]
+maximum = [int(x) for x in sys.argv[2].split(".")]
+version = [int(x) for x in sys.argv[3].split(".")]
+sys.exit(0 if minimum <= version <= maximum else 1)
+' "$minimum" "$maximum" "$condor_version"
+}
+
+
+# wait for the master to come up
+master_timeout=300
+SECONDS=0
+while [ ! -s "$CONDOR_LOGDIR/MasterLog" ]; do
+    if [ $SECONDS -gt $master_timeout ]; then
+        echo "Timeout: condor_master did not start within $master_timeout seconds." >&2
+        exit 1
+    fi
+    sleep 5
+done
+
+# wait for the startd to log something
+startd_timeout=120
+SECONDS=0
+while [ ! -s "$CONDOR_LOGDIR/StartLog" ]; do
+    if [ $SECONDS -gt $startd_timeout ]; then
+        echo "Timeout: condor_startd did not start within $startd_timeout seconds." >&2
+        exit 1
+    fi
+    sleep 5
+done
+
+# now wait for the startd to be registered
+startd_addr=$(condor_who -log $CONDOR_LOGDIR \
+                         -wait:300 'IsReady && STARTD_State =?= "Ready"' \
+                         -dae \
+                | awk '/^Startd/ {print $4}')
+ret=$?
+
+if [[ $ret -ne 0 || -z "$startd_addr" ]]; then
+    echo "Unable to determine startd addr" >&2
+    exit 1
+fi
+
+echo "$startd_addr"
+exit 0
+
+
+
+

--- a/sbin/startd_addr.sh
+++ b/sbin/startd_addr.sh
@@ -2,23 +2,6 @@
 
 CONDOR_LOGDIR=/pilot/log
 
-function condor_version_in_range {
-    local minimum maximum
-    minimum=${1:?minimum not provided to condor_version_in_range}
-    maximum=${2:-99.99.99}
-
-    local condor_version
-    condor_version=$(condor_version | awk '/CondorVersion/ {print $2}')
-    python3 -c '
-import sys
-minimum = [int(x) for x in sys.argv[1].split(".")]
-maximum = [int(x) for x in sys.argv[2].split(".")]
-version = [int(x) for x in sys.argv[3].split(".")]
-sys.exit(0 if minimum <= version <= maximum else 1)
-' "$minimum" "$maximum" "$condor_version"
-}
-
-
 # wait for the master to come up
 master_timeout=300
 SECONDS=0


### PR DESCRIPTION
`SIGTERM` and `SIGINT` will be trapped and mapped to the appropriate `condor_off` command.

You can choose strategy by setting the `SHUTDOWN_STRATEGY` environment variable to one of `peaceful`, `graceful` or `fast`. 

`graceful` provides 24 hours for jobs to finish.

`fast` is default for now, matching the current behavior. We could have policy discussion on how for example the RPM should shutdown. For K8s deployments, `graceful` with something like this works well:

    spec:
      terminationGracePeriodSeconds: 86400
      containers:
      ...
        env:
          - name: SHUTDOWN_STRATEGY
            value: "graceful"
