### PR TITLE
Wait for adv-base to finish

### DIFF
--- a/50-main.config
+++ b/50-main.config
@@ -60,7 +60,7 @@ STARTD_ATTRS = $(STARTD_ATTRS) GLIDEIN_Country GLIDEIN_Site GLIDEIN_ResourceName
 # For GPU containers, we check if we can fit some CPU-only jobs with RoomForCPUOnlyJobs
 START = (time() < GLIDEIN_ToRetire) && \
         (ifThenElse(TARGET.JobDurationCategory =?= "Long", GLIDEIN_ToDie - time() > 144000, True)) && \
-        (isUndefined(MY.OSG_NODE_VALIDATED) || MY.OSG_NODE_VALIDATED) && \
+        (MY.OSG_NODE_VALIDATED) && \
         (isUndefined(IsBlackHole) || IsBlackHole == False) && \
         (isUndefined(HasExcessiveLoad) || HasExcessiveLoad == False) && \
         ((DESIRED_Sites=?=undefined) || stringListMember(GLIDEIN_Site,DESIRED_Sites,",")) && \


### PR DESCRIPTION
We have observed ospool-ep containers start up, and accept jobs before advertise-base has finished verifying/advertising. One issue is that `OSPool` is not defined, and it makes the instance look like a "allocated" resource. This change waits for the `OSG_NODE_VALIDATED` attribute to show up - it is one of the last ones being advertised in advertise-base.