### PR TITLE
Fix failing CI due to broken startd readiness detection

### DIFF
--- a/tests/test_inside_gha.sh
+++ b/tests/test_inside_gha.sh
@@ -29,6 +29,7 @@ function start_singularity_backfill {
     su - testuser -c \
        "$singularity instance start \
           -B /cvmfs \
+          -B /dev/fuse \
           -B $PILOT_DIR:/pilot \
           -ci \
           docker-daemon:$CONTAINER_IMAGE \

--- a/tests/test_inside_gha.sh
+++ b/tests/test_inside_gha.sh
@@ -185,6 +185,7 @@ function test_singularity_startup {
                                     -af 'STARTD_State =?= \"Ready\"'")
 
     if [[ $startd_ready != "true" ]]; then
+        cat $SINGULARITY_OUTPUT
         cat "$CONDOR_LOGDIR/StartLog"
     fi
 }

--- a/tests/test_inside_gha.sh
+++ b/tests/test_inside_gha.sh
@@ -187,6 +187,7 @@ function test_singularity_startup {
     if [[ $startd_ready != "true" ]]; then
         cat $SINGULARITY_OUTPUT
         cat "$CONDOR_LOGDIR/StartLog"
+        return 1
     fi
 }
 

--- a/tests/test_inside_gha.sh
+++ b/tests/test_inside_gha.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -x
 
 OSP_TOKEN_PATH=/tmp/token
+CONDOR_LOGDIR=/pilot/log
 COMMON_DOCKER_ARGS="run --user osg
                         --detach
                         --security-opt apparmor=unconfined
@@ -154,9 +155,7 @@ function test_docker_HAS_SINGULARITY {
         direct="-direct"
     fi
 
-    logdir=$(run_inside_backfill_container find /pilot -type d -name log); ret=$?
-    [[ $ret -eq $ABORT_CODE ]] && { debug_docker_backfill; return $ABORT_CODE; }
-    startd_addr=$(run_inside_backfill_container condor_who -log $logdir -dae | awk '/^Startd/ {print $6}'); ret=$?
+    startd_addr=$(run_inside_backfill_container condor_who -log $CONDOR_LOGDIR -dae | awk '/^Startd/ {print $6}'); ret=$?
     [[ $ret -eq $ABORT_CODE ]] && { debug_docker_backfill; return $ABORT_CODE; }
     echo "startd addr: $startd_addr"
     has_singularity=$(run_inside_backfill_container \


### PR DESCRIPTION
It's not entirely clear what changed but looking for the `Changing activity: Benchmarking -> Idle` sentinel in the `StartLog` no longer works. Maybe the string changed, maybe benchmarking is taking slightly longer. Either way, the HTCondor team uses `condor_who -wait` in their own tests and what's good for the goose...