### PR TITLE
INF-2962: ensure that Go debugger is installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN useradd osg \
         bind-utils \
         socat \
         tini \
+        delve \
  && if [[ $BASE_OS != el9 ]]; then yum -y install redhat-lsb-core; fi \
  && yum clean all \
  && mkdir -p /etc/condor/passwords.d /etc/condor/tokens.d


### PR DESCRIPTION
Mat noted that we won't be able to `yum install delve` when we need it since containers start as the unpriv user