### PR TITLE
Don't attempt to merge el10 artifacts

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -155,7 +155,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['el9', 'el10', 'cuda_11_8_0']
+        os: ['el9', 'cuda_11_8_0']
         repo: ['development', 'testing', 'release']
         osg_series: ['24', '25']
         registry: [


### PR DESCRIPTION
We don't build el10 images; this makes the merge-manifests step fail when it tries to merge el10 manifests. Remove el10 from the merge-manifests matrix, to match the build matrix.