### PR TITLE
Update and pin non-opensciencegrid GitHub actions

### DIFF
--- a/.github/actions/push-digest-local/action.yaml
+++ b/.github/actions/push-digest-local/action.yaml
@@ -42,7 +42,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
   - id: slash-escape
     shell: bash
@@ -55,7 +55,7 @@ runs:
       github.ref == 'refs/heads/master' &&
       github.event_name != 'pull_request' &&
       contains(fromJson('["opensciencegrid","osg-htc"]'), github.repository_owner)
-    uses: docker/login-action@v2
+    uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
     with:
       registry: ${{ inputs.registry }}
       username: ${{ inputs.username }}
@@ -82,7 +82,7 @@ runs:
       touch "/tmp/${{ inputs.registry }}/digests/${digest#sha256:}"
 
   - name: Upload digest
-    uses: actions/upload-artifact@v4
+    uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
     with:
       name: digests-${{ inputs.registry }}-${{ inputs.base_tag }}-${{ steps.slash-escape.outputs.platform }}
       path: /tmp/${{ inputs.registry }}/digests/*
@@ -96,7 +96,7 @@ runs:
       echo ${{ steps.upload-image.outputs.image-list }} > /tmp/${{ inputs.registry }}/tags/${{ inputs.base_tag }}-${{ steps.slash-escape.outputs.platform }}
     
   - name: Upload tags
-    uses: actions/upload-artifact@v4
+    uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
     with:
       name: tags-${{ inputs.registry }}-${{ inputs.base_tag }}-${{ steps.slash-escape.outputs.platform }}
       path: /tmp/${{ inputs.registry }}/tags/*

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -32,7 +32,7 @@ jobs:
           - os: el10
             osg_series: '24'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - id: custom-image-name
         env:
@@ -191,14 +191,14 @@ jobs:
         echo "base_tag=${SERIES}-${OS}-${REPO}" >> ${GITHUB_OUTPUT}
 
     - name: Download digests
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         path: /tmp/${{ matrix.registry.url }}/digests
         pattern: digests-${{ matrix.registry.url }}-${{ steps.base-tag.outputs.base_tag }}-*
         merge-multiple: true
     
     - name: Download tags
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         path: /tmp/${{ matrix.registry.url }}/tags
         pattern: tags-${{ matrix.registry.url }}-${{ steps.base-tag.outputs.base_tag }}-*
@@ -218,10 +218,10 @@ jobs:
         done
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
     
     - name: Registry login
-      uses: docker/login-action@v2
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
       with:
         registry: ${{ matrix.registry.url }}
         username: ${{ secrets[matrix.registry.username] }}


### PR DESCRIPTION
actions/checkout: v3 -> v7.0.1
docker/login-action: v2 -> v4.6.0
actions/upload-artifact: v4 -> v7.0.1
actions/download-artifact: v4 -> v8.0.1
docker/setup-buildx-action: v2 -> v4.2.0